### PR TITLE
FIX remove basket features from csv export in cmd/decode

### DIFF
--- a/attelo/cmd/decode.py
+++ b/attelo/cmd/decode.py
@@ -145,7 +145,7 @@ def _export_csv(phrasebook, doc, predicted, attach_instances, folder):
     if not os.path.exists(folder):
         os.makedirs(folder)
     predicted_map = {(e1, e2): label for e1, e2, label in predicted}
-    metas = attach_instances.domain.getmetas().values()
+    metas = attach_instances.domain.getmetas(False).values()
 
     with open(fname, 'wb') as fout:
         writer = csv.writer(fout)


### PR DESCRIPTION
Orange encodes basket features as optional meta attributes.
The CSV export in `cmd/decode.py` now outputs only the mandatory meta attributes, which correspond to true meta attributes, excluding basket features.
