### PR TITLE
FIX introduce predict_score instead of transform for learners

### DIFF
--- a/attelo/learning/__init__.py
+++ b/attelo/learning/__init__.py
@@ -24,7 +24,7 @@ either
 
 * `predict_proba(X)`: given a feature matrix return a probability
    matrix, each row being the vector of probabilities that a pair
-   is unattached or attached (in pracitce we're just interested in
+   is unattached or attached (in practice we're just interested in
    the latter)
 * `decision_function(X)`: given a feature matrix, return a vector
    of attachment scores

--- a/attelo/learning/interface.py
+++ b/attelo/learning/interface.py
@@ -50,7 +50,7 @@ class AttachClassifier(with_metaclass(ABCMeta, object)):
         raise NotImplementedError
 
     @abstractmethod
-    def transform(self, dpack):
+    def predict_score(self, dpack):
         """
         Parameters
         ----------
@@ -109,7 +109,7 @@ class LabelClassifier(with_metaclass(ABCMeta, object)):
         raise NotImplementedError
 
     @abstractmethod
-    def transform(self, dpack):
+    def predict_score(self, dpack):
         """
         Parameters
         ----------

--- a/attelo/learning/local.py
+++ b/attelo/learning/local.py
@@ -103,7 +103,7 @@ class SklearnAttachClassifier(AttachClassifier, SklearnClassifier):
         self._fitted = True
         return self
 
-    def transform(self, dpack):
+    def predict_score(self, dpack):
         if not self._fitted:
             raise ValueError('Fit not yet called')
         elif self.can_predict_proba:
@@ -144,7 +144,7 @@ class SklearnLabelClassifier(LabelClassifier, SklearnClassifier):
         self._fitted = True
         return self
 
-    def transform(self, dpack):
+    def predict_score(self, dpack):
         dpack, _ = for_labelling(dpack, dpack.target)
         if self._labels is None:
             raise ValueError('No labels associated with this classifier')

--- a/attelo/learning/oracle.py
+++ b/attelo/learning/oracle.py
@@ -32,7 +32,8 @@ class AttachOracle(AttachClassifier):
     def fit(self, dpacks, targets):
         return self
 
-    def transform(self, dpack):
+    # FIXME should be predict_proba(self, dpacks)
+    def predict_score(self, dpack):
         # nb: this isn't actually faster with vectorize
         to_prob = lambda x: 1.0 if x == 1.0 else 0.0
         return np_vectorize(to_prob)(dpack.target)
@@ -44,7 +45,7 @@ class LabelOracle(LabelClassifier):
     1.0 for the gold label and 0.0 other labels.
 
     Note: edges which are unrelated in the gold will be
-    assigned the a special "unknown" label (something like
+    assigned the special "unknown" label (something like
     '__UNK__')
 
     Naturally, this would only do something useful if the
@@ -57,7 +58,8 @@ class LabelOracle(LabelClassifier):
     def fit(self, dpacks, targets):
         return self
 
-    def transform(self, dpack):
+    # FIXME should be predict_proba(self, dpacks)
+    def predict_score(self, dpack):
         weights = dok_matrix((len(dpack), len(dpack.labels)))
         lbl_unrelated = dpack.label_number(UNRELATED)
         lbl_unk = dpack.label_number(UNKNOWN)

--- a/attelo/learning/perceptron.py
+++ b/attelo/learning/perceptron.py
@@ -216,7 +216,7 @@ class StructuredPerceptron(Perceptron):
         self.learn( datapacks ) 
         return self
 
-    def transform(self, dpack):
+    def predict_score(self, dpack):
         return self.decision_function(dpack.data)
 
     def learn(self, datapacks):

--- a/attelo/parser/attach.py
+++ b/attelo/parser/attach.py
@@ -62,7 +62,7 @@ class AttachClassifierWrapper(Parser):
 
     def transform(self, dpack):
         attach_pack, _ = for_attachment(dpack, dpack.target)
-        weights_a = self._learner_attach.transform(attach_pack)
+        weights_a = self._learner_attach.predict_score(attach_pack)
         return self.multiply(dpack, attach=weights_a)
 
 

--- a/attelo/parser/label.py
+++ b/attelo/parser/label.py
@@ -61,7 +61,7 @@ class LabelClassifierWrapper(Parser):
 
     def transform(self, dpack):
         dpack, _ = for_labelling(dpack, dpack.target)
-        return self.multiply(dpack, label=self._learner.transform(dpack))
+        return self.multiply(dpack, label=self._learner.predict_score(dpack))
 
 
 class SimpleLabeller(LabelClassifierWrapper):


### PR DESCRIPTION
Learners provide scores for edges through a new method, `predict_score`, rather than the previously used `transform` which has a different semantics in sklearn's API.

Sklearn classifiers provide a few methods, among which we routinely use:
* `predict`,
* `predict_proba`,
* `decision_function`
Sklearn classifiers also provide a `transform` method (from a mixin) which reduces the input to its most important features, cf. the doc for [LogisticRegression](http://scikit-learn.org/stable/modules/generated/sklearn.linear_model.LogisticRegression.html#sklearn.linear_model.LogisticRegression.transform) .
The `transform` methods in `attelo.learning` effectively provide scores, like the `predict_proba` and `decision_function` methode they call under the hood.