### PR TITLE
[MRG] FIX 10.000 speedup for function: do not create a numpy array of objects

### DIFF
--- a/attelo/parser/intra.py
+++ b/attelo/parser/intra.py
@@ -240,7 +240,7 @@ class IntraInterParser(with_metaclass(ABCMeta, Parser)):
         ------
         get_lbl: int -> int or None
         """
-        sub_idxes = np.array(locate_in_subpacks(dpack, subpacks))
+        sub_idxes = locate_in_subpacks(dpack, subpacks)
 
         def get_lbl(i):
             'retrieve lbl if present'


### PR DESCRIPTION
This PR is a one-line fix for a function (`_mk_get_lbl`) called in intra/inter-sentential parsing.
It avoids creating numpy arrays of objects, using plain Python lists instead.
This simple fix achieves a 10.000 speedup for this function.