### PR TITLE
[MRG] ENH usability of in-house perceptrons, local and structured

### DIFF
--- a/attelo/decoding/tests.py
+++ b/attelo/decoding/tests.py
@@ -16,15 +16,6 @@ from .eisner import EisnerDecoder
 from .util import (prediction_to_triples, simple_candidates)
 
 # pylint: disable=too-few-public-methods
-# default values for perceptron learner
-
-#DEFAULT_USE_PROB = True
-#DEFAULT_PERCEPTRON_ARGS = PerceptronArgs(iterations=20,
-#                                         averaging=True,
-#                                         use_prob=DEFAULT_USE_PROB,
-#                                         aggressiveness=inf)
-
-# DEFAULT_MST_ROOT = MstRootStrategy.fake_root
 
 # default values for A* decoder
 # (NB: not the same as in the default initialiser)

--- a/attelo/learning/__init__.py
+++ b/attelo/learning/__init__.py
@@ -52,8 +52,7 @@ from .oracle import (AttachOracle,
                      LabelOracle)
 
 
-from .perceptron import (PerceptronArgs,
-                         Perceptron,
+from .perceptron import (Perceptron,
                          PassiveAggressive,
                          StructuredPerceptron,
                          StructuredPassiveAggressive)

--- a/attelo/learning/perceptron.py
+++ b/attelo/learning/perceptron.py
@@ -82,7 +82,6 @@ class Perceptron(object):
         print("FEAT. SPACE SIZE:", dim)
         self.weights = zeros(dim, 'd')
         self.avg_weights = zeros(dim, 'd')
-        return
 
     def learn(self, X, Y):
         start_time = time.time()
@@ -110,7 +109,6 @@ class Perceptron(object):
             print("\ttime = %-4s" % round(t1-t0, 3), file=sys.stderr)
         elapsed_time = t1-start_time
         print("done in %s sec." % round(elapsed_time, 3), file=sys.stderr)
-        return
 
     def update(self, Y_j_hat, Y_j, X_j, score):
         """ simple perceptron update rule"""
@@ -214,13 +212,11 @@ class StructuredPerceptron(Perceptron):
                             average=average,
                             use_prob=use_prob)
         self.decoder = decoder
-        return
 
     def init_model(self, dim):
         print("FEAT. SPACE SIZE:", dim)
         self.weights = zeros(dim, 'd')
         self.avg_weights = zeros(dim, 'd')
-        return
 
     def fit(self, datapacks, _targets):  # datapacks is an iterable
         """ learn struct. perceptron weights """
@@ -267,7 +263,6 @@ class StructuredPerceptron(Perceptron):
             print("\ttime = %-4s" % round(t1-t0, 3), file=sys.stderr)
         elapsed_time = t1-start_time
         print("done in %s sec." % round(elapsed_time, 3), file=sys.stderr)
-        return
 
     def update(self, pred_tree, ref_tree, X, fv_map):
         rate = self.eta0

--- a/attelo/learning/perceptron.py
+++ b/attelo/learning/perceptron.py
@@ -133,20 +133,26 @@ class Perceptron(object):
 
 
 class PassiveAggressive(Perceptron):
-    """
-    Passive-Aggressive classifier in primal form. PA has a
-    margin-based update rule: each update yields at least a margin
-    of one (see defails below). Specifically, we implement PA-II
-    rule for the binary setting (see Crammer et. al 2006). Default
-    C=inf parameter makes it equivalent to simple PA.
+    """Passive-Aggressive classifier in primal form.
+
+    PA has a margin-based update rule: each update yields at least a
+    margin of one (see details below). Specifically, we implement the
+    PA-I rule for the binary setting (see Crammer et. al 2006).
+    Setting parameter C=inf makes it equivalent to basic PA.
 
     Parameters
     ----------
     C: float
         Maximum step size (regularization). Also known as the
         aggressiveness parameter.
-        `inf` gets us a regular perceptron.
+        `np.inf` makes it equivalent to basic PA.
         Defaults to 1.0.
+
+    Notes
+    -----
+    TODO:
+        [ ] implement the PA-II variant and add parameter "loss" to
+        choose rule.
     """
 
     def __init__(self, C=1.0,
@@ -161,7 +167,7 @@ class PassiveAggressive(Perceptron):
         self.C = C
 
     def update(self, Y_j_hat, Y_j, X_j, score):
-        r"""PA-II update rule
+        r"""PA-I update rule
 
         .. math::
 

--- a/attelo/parser/intra.py
+++ b/attelo/parser/intra.py
@@ -47,10 +47,10 @@ class IntraInterPair(namedtuple("IntraInterPair",
 def for_intra(dpack, target):
     """Adapt a datapack to intrasentential decoding.
 
-    An intrasenential datapack is almost identical to its original, except that
-    we set the label for each ('ROOT', edu) pairing to 'ROOT' if that edu is a
-    subgrouping head (if it has no parents other than than 'ROOT' within its
-    subgrouping).
+    An intrasentential datapack is almost identical to its original,
+    except that we set the label for each ('ROOT', edu) pairing to
+    'ROOT' if that edu is a subgrouping head (if it has no parents other
+    than than 'ROOT' within its subgrouping).
 
     This should be done before either `for_labelling` or `for_attachment`
 
@@ -93,7 +93,7 @@ def for_intra(dpack, target):
 
 def _zip_sentences(func, sent_parses):
     """
-    Given a function that combines sentence predictions, and a
+    Given a function that combines sentence predictions, and
     given a list of predictions for each sentence (eg. the
     3 best predictions for each sentence), apply that function
     over each list that goes together (eg. on best predictions

--- a/attelo/parser/tests.py
+++ b/attelo/parser/tests.py
@@ -25,8 +25,7 @@ from attelo.decoding.window import (WindowPruner)
 from attelo.edu import EDU, FAKE_ROOT, FAKE_ROOT_ID
 from attelo.learning.local import (SklearnAttachClassifier,
                                    SklearnLabelClassifier)
-from attelo.learning.perceptron import (PerceptronArgs,
-                                        StructuredPerceptron)
+from attelo.learning.perceptron import (StructuredPerceptron)
 from attelo.table import (DataPack)
 from attelo.util import (Team)
 
@@ -44,10 +43,6 @@ from .intra import (HeadToHeadParser,
 # pylint: disable=too-few-public-methods
 
 
-LOCAL_PERC_ARGS = PerceptronArgs(iterations=3,
-                                 averaging=True,
-                                 use_prob=False,
-                                 aggressiveness=np.inf)
 DEFAULT_ASTAR_ARGS = AstarArgs(heuristics=Heuristic.average,
                                rfc=RfcConstraint.none,
                                beam=None,
@@ -101,12 +96,13 @@ class ParserTest(DecoderTest):
             self._test_parser(parser)
 
     def test_postlabel_parser(self):
-        learners = LEARNERS +\
-            [
-                 Team(attach=StructuredPerceptron(MST_DECODER,
-                                                  LOCAL_PERC_ARGS),
-                      label=SklearnLabelClassifier(LogisticRegression())),
-            ]
+        learners = LEARNERS + [
+            Team(attach=StructuredPerceptron(MST_DECODER,
+                                             n_iter=3,
+                                             average=True,
+                                             use_prob=False),
+                 label=SklearnLabelClassifier(LogisticRegression())),
+        ]
         for l, d in itr.product(learners, DECODERS):
             parser = PostlabelPipeline(learner_attach=l.attach,
                                        learner_label=l.label,
@@ -183,7 +179,6 @@ class IntraTest(unittest.TestCase):
 
         self.assertEqual(all_valid, all_subgroupings)
         self.assertEqual(len(all_subgroupings), len(partitions))
-
 
     def test_for_intra(self):
         'test that sentence roots are identified correctly'


### PR DESCRIPTION
This PR gathers a variety of changes that together aim at improving the usability of the in-house perceptrons, both local and structured.

In detail:
* changes in the API of the in-house perceptrons to match that of their equivalent or siblings in sklearn,
* fixes in a few docstrings
* removal of some empty returns in the perceptrons' code, as these mess exception traces
* addition of a trigger for unique vs multiple real roots in the Eisner decoder, that enable its proper use in two-stage (intra- then inter-sentential) parsers ; this problem is not directly related to the perceptrons, but was spotted while working on the perceptrons so I got lazy and overloaded this branch.