### PR TITLE
[MRG] FIX inspect: add UNKNOWN label

### DIFF
--- a/attelo/cmd/inspect.py
+++ b/attelo/cmd/inspect.py
@@ -7,6 +7,7 @@ from ..args import (add_model_read_args)
 from ..io import (load_labels, load_model, load_vocab)
 from ..score import (discriminating_features)
 from ..report import (show_discriminating_features)
+from ..table import UNKNOWN
 from ..util import (Team)
 
 # ---------------------------------------------------------------------
@@ -39,7 +40,10 @@ def main(args):
     "subcommand main (invoked from outer script)"
     models = Team(attach=load_model(args.attachment_model),
                   label=load_model(args.relation_model))
-    labels = load_labels(args.features)
+    # FIXME find a clean way to properly read ready-for-use labels
+    # upstream ; true labels are 1-based in svmlight format but 0-based
+    # for sklearn
+    labels = [UNKNOWN] + load_labels(args.features)
     vocab = load_vocab(args.vocab)
     discr = discriminating_features(models, labels, vocab, args.top)
     res = show_discriminating_features(discr)


### PR DESCRIPTION
This PR fixes the `attelo inspect` utility by automatically pre-pending UNKNOWN to the list of labels.