### PR TITLE
ENH tree loss, ctree eval, FrontierToHead intra/inter, nonfixed_pairs

### DIFF
--- a/attelo/decoding/baseline.py
+++ b/attelo/decoding/baseline.py
@@ -17,7 +17,8 @@ class LocalBaseline(Decoder):
     def __init__(self, threshold, use_prob=True):
         self._threshold = threshold if use_prob else 0.0
 
-    def decode(self, dpack):
+    def decode(self, dpack, nonfixed_pairs=None):
+        # TODO integrate nonfixed_pairs, maybe?
         cands = simple_candidates(dpack)
         results = [(e1.id, e2.id, lab) for e1, e2, w, lab in cands
                    if w > self._threshold]
@@ -27,7 +28,8 @@ class LocalBaseline(Decoder):
 class LastBaseline(Decoder):
     "attach to last, always"
 
-    def decode(self, dpack):
+    def decode(self, dpack, nonfixed_pairs=None):
+        # TODO integrate nonfixed_pairs, maybe?
         cands = simple_candidates(dpack)
         labels_probs = get_prob_map(cands)
 

--- a/attelo/decoding/eisner.py
+++ b/attelo/decoding/eisner.py
@@ -31,7 +31,7 @@ class EisnerDecoder(Decoder):
         self._unique_real_root = unique_real_root
         self._use_prob = use_prob  # yerk
 
-    def decode(self, dpack):
+    def decode(self, dpack, nonfixed_pairs=None):
         """Decode
 
         Parameters

--- a/attelo/decoding/eisner.py
+++ b/attelo/decoding/eisner.py
@@ -6,7 +6,8 @@ import numpy as np
 from .interface import Decoder
 # temporary? imports
 from ..table import _edu_positions
-from .util import convert_prediction, simple_candidates
+from .util import (cap_score, convert_prediction, simple_candidates,
+                   MIN_SCORE)
 
 
 class EisnerDecoder(Decoder):
@@ -61,7 +62,7 @@ class EisnerDecoder(Decoder):
         # be adapted before this point ;
         # should be (src, tgt): attach_score
         score = {(edu_id2idx[src.id], edu_id2idx[tgt.id]):
-                 (np.log(attach_score) if self._use_prob
+                 (cap_score(np.log(attach_score)) if self._use_prob
                   else attach_score)
                  for src, tgt, attach_score, best_lbl
                  in simple_cands}
@@ -75,7 +76,7 @@ class EisnerDecoder(Decoder):
         # arrays of substructures for dynamic programming
         # [start][end][dir][complete]
         # scores
-        cscores = np.zeros((nb_edus, nb_edus, 2, 2), dtype=np.float32)
+        cscores = np.zeros((nb_edus, nb_edus, 2, 2), dtype=np.float64)
         # backpointers: index of split point
         csplits = np.zeros((nb_edus, nb_edus, 2, 2), dtype=np.int32)
 
@@ -97,7 +98,7 @@ class EisnerDecoder(Decoder):
                                    if not np.isnan(max_cand)
                                    else range_k[0])
                 else:
-                    max_cand = np.nan
+                    max_cand = MIN_SCORE  # was: np.nan
                     argmax_cand = range_k[0]
                 # update tables
                 cscores[start][end][1][0] = max_cand
@@ -122,7 +123,7 @@ class EisnerDecoder(Decoder):
                                    if not np.isnan(max_cand)
                                    else range_k[0])
                 else:
-                    max_cand = np.nan
+                    max_cand = MIN_SCORE  # was: np.nan
                     argmax_cand = range_k[0]
                 # update tables
                 cscores[start][end][0][0] = max_cand
@@ -140,7 +141,7 @@ class EisnerDecoder(Decoder):
                                    if not np.isnan(max_cand)
                                    else range_k[0])
                 else:
-                    max_cand = np.nan
+                    max_cand = MIN_SCORE  # was: np.nan
                     argmax_cand = range_k[0]
                 # update tables
                 cscores[start][end][1][1] = max_cand

--- a/attelo/decoding/eisner.py
+++ b/attelo/decoding/eisner.py
@@ -87,62 +87,51 @@ class EisnerDecoder(Decoder):
 
                 # left open
                 range_k = range(start, end)
-                if start > 0 and (end, start) in score:
-                    # find argmax and max on range_k
-                    cands = [(cscores[start][k][0][1] +
-                              cscores[k + 1][end][1][1] +
-                              score[(end, start)])
-                             for k in range_k]
-                    max_cand = np.nanmax(cands)
-                    argmax_cand = (range_k[cands.index(max_cand)]
-                                   if not np.isnan(max_cand)
-                                   else range_k[0])
-                else:
-                    max_cand = MIN_SCORE  # was: np.nan
-                    argmax_cand = range_k[0]
+                # find argmax and max on range_k
+                cands = [(cscores[start][k][0][1] +
+                          cscores[k + 1][end][1][1] +
+                          (score[(end, start)]
+                           if start > 0 and (end, start) in score
+                           else MIN_SCORE))
+                         for k in range_k]
+                max_cand = np.nanmax(cands)
+                argmax_cand = (range_k[cands.index(max_cand)]
+                               if not np.isnan(max_cand)
+                               else range_k[0])
                 # update tables
                 cscores[start][end][1][0] = max_cand
                 csplits[start][end][1][0] = argmax_cand
 
                 # right open
-                if unique_real_root and start == 0:
-                    # if start == 0, restricting range_k to [0]
-                    # enforces that the tree has a unique real root
-                    range_k = [0]
-                else:
-                    range_k = range(start, end)
-                #
-                if (start, end) in score:
-                    # find argmax and max on range_k
-                    cands = [(cscores[start][k][0][1] +
-                              cscores[k + 1][end][1][1] +
-                              score[(start, end)])
-                             for k in range_k]
-                    max_cand = np.nanmax(cands)
-                    argmax_cand = (range_k[cands.index(max_cand)]
-                                   if not np.isnan(max_cand)
-                                   else range_k[0])
-                else:
-                    max_cand = MIN_SCORE  # was: np.nan
-                    argmax_cand = range_k[0]
+                # if start == 0, restricting range_k to [0]
+                # enforces that the tree has a unique real root
+                range_k = ([0] if unique_real_root and start == 0
+                           else range(start, end))
+                # find argmax and max on range_k
+                cands = [(cscores[start][k][0][1] +
+                          cscores[k + 1][end][1][1] +
+                          (score[(start, end)]
+                           if (start, end) in score
+                           else MIN_SCORE))
+                         for k in range_k]
+                max_cand = np.nanmax(cands)
+                argmax_cand = (range_k[cands.index(max_cand)]
+                               if not np.isnan(max_cand)
+                               else range_k[0])
                 # update tables
                 cscores[start][end][0][0] = max_cand
                 csplits[start][end][0][0] = argmax_cand
 
-                # left closed: impossible if start == fake root
+                # left closed
                 range_k = range(start, end)
-                if start > 0:
-                    # find argmax and max on range_k
-                    cands = [(cscores[start][k][1][1] +
-                              cscores[k][end][1][0])
-                             for k in range_k]
-                    max_cand = np.nanmax(cands)
-                    argmax_cand = (range_k[cands.index(max_cand)]
-                                   if not np.isnan(max_cand)
-                                   else range_k[0])
-                else:
-                    max_cand = MIN_SCORE  # was: np.nan
-                    argmax_cand = range_k[0]
+                # find argmax and max on range_k
+                cands = [(cscores[start][k][1][1] +
+                          cscores[k][end][1][0])
+                         for k in range_k]
+                max_cand = np.nanmax(cands)
+                argmax_cand = (range_k[cands.index(max_cand)]
+                               if not np.isnan(max_cand)
+                               else range_k[0])
                 # update tables
                 cscores[start][end][1][1] = max_cand
                 csplits[start][end][1][1] = argmax_cand

--- a/attelo/decoding/interface.py
+++ b/attelo/decoding/interface.py
@@ -48,9 +48,9 @@ class Decoder(with_metaclass(ABCMeta, Parser)):
         '''
         raise NotImplementedError
 
-    def fit(self, dpacks, targets, cache=None):
+    def fit(self, dpacks, targets, nonfixed_pairs=None, cache=None):
         return
 
-    def transform(self, dpack):
+    def transform(self, dpack, nonfixed_pairs=None):
         dpack = self.multiply(dpack) # default weights if not set
-        return self.decode(dpack)
+        return self.decode(dpack, nonfixed_pairs=nonfixed_pairs)

--- a/attelo/decoding/mst.py
+++ b/attelo/decoding/mst.py
@@ -16,28 +16,11 @@ from ..edu import FAKE_ROOT_ID
 from ..util import ArgparserEnum
 from .interface import Decoder
 from .util import (DecoderException,
+                   cap_score,
                    convert_prediction,
                    simple_candidates)
 
 # pylint: disable=too-few-public-methods
-
-# see _cap_score
-MAX_SCORE = 1e90
-MIN_SCORE = -MAX_SCORE
-
-
-def _cap_score(score):
-    '''
-    the depparse package's MST implementation uses a hardcoded minimum score of
-    `-1e100`.
-    Feeding it lower weights crashes the algorithm
-    We set minimum and maximum scores to avoid this
-    Unless we have more than 1e10 nodes, combined scores can't reach the limit
-
-    :type score: float
-    :rtype: float
-    '''
-    return min(MAX_SCORE, max(MIN_SCORE, score))
 
 
 def _leftmost_edu(edus):
@@ -127,7 +110,7 @@ class MstDecoder(Decoder):
                 continue
 
             if self._use_prob:
-                scores[src, tgt] = _cap_score(logit(prob))
+                scores[src, tgt] = cap_score(logit(prob))
             else:
                 scores[src, tgt] = prob
             labels[src, tgt] = rel

--- a/attelo/decoding/mst.py
+++ b/attelo/decoding/mst.py
@@ -120,7 +120,8 @@ class MstDecoder(Decoder):
                        lambda s, t: scores[s, t],
                        lambda s, t: labels[s, t])
 
-    def decode(self, dpack):
+    def decode(self, dpack, nonfixed_pairs=None):
+        # TODO integrate nonfixed_pairs, maybe?
         graph = self._graph(simple_candidates(dpack))
         subgraph = graph.mst()
         predictions = [(src, tgt, subgraph.get_label(src, tgt))
@@ -131,7 +132,8 @@ class MstDecoder(Decoder):
 class MsdagDecoder(MstDecoder):
     """ Attach according to MSDAG (subgraph of original)"""
 
-    def decode(self, dpack):
+    def decode(self, dpack, nonfixed_pairs=None):
+        # TODO integrate nonfixed_pairs, maybe?
         graph = self._graph(simple_candidates(dpack))
         subgraph = _msdag(graph)
         predictions = [(src, tgt, subgraph.get_label(src, tgt))

--- a/attelo/decoding/tests.py
+++ b/attelo/decoding/tests.py
@@ -75,6 +75,7 @@ class DecoderTest(unittest.TestCase):
                                                [3, 3, 1],
                                                [0, 6, 3]])),
                      target=np.array([0, 0, 0, 0, 0, 0]),
+                     ctarget=dict(),  # WIP
                      graph=graph,
                      vocab=None)
 

--- a/attelo/decoding/util.py
+++ b/attelo/decoding/util.py
@@ -7,6 +7,37 @@ import numpy as np
 from attelo.table import (Graph, UNRELATED)
 
 
+# see cap_score
+# the current value (1e90) works with float64 scores but overflows float32
+# so be careful with dtypes in the decoders
+MAX_SCORE = 1e90
+MIN_SCORE = -MAX_SCORE
+
+
+def cap_score(score):
+    """Cap a real-valued score between `MIN_SCORE` and `MAX_SCORE`.
+
+    The current default values for `MIN_SCORE` and `MAX_SCORE` follow the
+    requirements from the decoders:
+    * The MST decoder uses the depparse package whose MST implementation
+    has a hardcoded minimum score of `-1e100` ; Feeding it lower weights
+    crashes the algorithm. Combined scores can't reach the limit unless
+    we have more than 1e10 nodes.
+    * The Eisner decoder internally uses float64 scores.
+
+    Parameters
+    ----------
+    score : float
+        Original score.
+
+    Returns
+    -------
+    bounded_score : float
+        Score bounded to [MIN_SCORE, MAX_SCORE].
+    """
+    return min(MAX_SCORE, max(MIN_SCORE, score))
+
+
 class DecoderException(Exception):
     """
     Exceptions that arise during the decoding process

--- a/attelo/harness/evaluate.py
+++ b/attelo/harness/evaluate.py
@@ -133,7 +133,7 @@ def _create_tstamped_dir(prefix, suffix):
 
 def prepare_dirs(runcfg, data_dir):
     """
-    Return eval and scatch directory paths
+    Return eval and scratch directory paths
     """
     eval_prefix = fp.join(data_dir, "eval")
     scratch_prefix = fp.join(data_dir, "scratch")
@@ -225,15 +225,17 @@ def _load_harness_multipack(hconf, test_data=False):
     """
     stripped_paths = hconf.mpack_paths(test_data, stripped=True)
     if (hconf.runcfg.stage in [ClusterStage.end, ClusterStage.start] and
-            fp.exists(stripped_paths[2])):
+        fp.exists(stripped_paths[2])):
         paths = stripped_paths
     else:
         paths = hconf.mpack_paths(test_data, stripped=False)
-    return load_multipack(paths[0],
-                          paths[1],
-                          paths[2],
-                          paths[3],
-                          verbose=True)
+    mpack = load_multipack(paths[0],
+                           paths[1],
+                           paths[2],
+                           paths[3],
+                           paths[4],  # FIXME not a path: corpus reader
+                           verbose=True)
+    return mpack
 
 
 def _init_corpus(hconf):

--- a/attelo/harness/evaluate.py
+++ b/attelo/harness/evaluate.py
@@ -233,7 +233,8 @@ def _load_harness_multipack(hconf, test_data=False):
                            paths[1],
                            paths[2],
                            paths[3],
-                           paths[4],  # FIXME not a path: corpus reader
+                           corpus_path=(paths[4] if len(paths) == 5
+                                        else None),  # WIP
                            verbose=True)
     return mpack
 

--- a/attelo/harness/example.py
+++ b/attelo/harness/example.py
@@ -104,7 +104,7 @@ class TinyHarness(Harness):
                                task=mtype,
                                ext=ext)
 
-    def model_paths(self, rconf, fold):
+    def model_paths(self, rconf, fold, parser):
         if fold is None:
             parent_dir = self.combined_dir_path()
         else:

--- a/attelo/harness/interface.py
+++ b/attelo/harness/interface.py
@@ -204,7 +204,7 @@ class Harness(with_metaclass(ABCMeta, object)):
         return NotImplementedError
 
     @abstractmethod
-    def model_paths(self, rconf, fold):
+    def model_paths(self, rconf, fold, parser):
         """Return attelo model paths in dictionary form
 
         Parameters

--- a/attelo/harness/parse.py
+++ b/attelo/harness/parse.py
@@ -67,6 +67,35 @@ def _parse_group(dpack, parser, output_path):
     write_predictions_output(dpack, prediction, output_path)
 
 
+def jobs(mpack, parser, output_path):
+    """Get a list of delayed decoding jobs for the documents in this group.
+
+    Parameters
+    ----------
+    mpack : DataPack
+        TODO
+    parser : TODO
+        TODO
+    output_path : string
+        Output path
+
+    Returns
+    -------
+    res : list of delayed calls produced by joblib.delayed
+    """
+    # * clean temp files
+    tmpfiles = [_tmp_output_filename(output_path, d)
+                for d in mpack.keys()]
+    for tmpfile in tmpfiles:
+        if fp.exists(tmpfile):
+            os.remove(tmpfile)
+    # * generate delayed decoding jobs
+    res = [delayed(_parse_group)(dpack, parser,
+                                 _tmp_output_filename(output_path, onedoc))
+           for onedoc, dpack in mpack.items()]
+    return res
+
+
 def learn(hconf, econf, dconf, fold):
     """
     Run the learners for the given configuration
@@ -107,19 +136,7 @@ def delayed_decode(hconf, dconf, econf, fold):
 
     parser = econf.parser.payload
 
-    # create list of delayed decoding jobs for the various documents in
-    # this group (subpack)
-    # * clean temp files
-    tmpfiles = [_tmp_output_filename(output_path, d)
-                for d in subpack.keys()]
-    for tmpfile in tmpfiles:
-        if fp.exists(tmpfile):
-            os.remove(tmpfile)
-    # * generate delayed decoding jobs
-    res = [delayed(_parse_group)(dpack, parser,
-                                 _tmp_output_filename(output_path, onedoc))
-           for onedoc, dpack in subpack.items()]
-
+    res = jobs(subpack, parser, output_path)
     return res
 
 

--- a/attelo/harness/parse.py
+++ b/attelo/harness/parse.py
@@ -80,7 +80,7 @@ def learn(hconf, econf, dconf, fold):
 
     if not os.path.exists(parent_dir):
         os.makedirs(parent_dir)
-    cache = hconf.model_paths(econf.learner, fold)
+    cache = hconf.model_paths(econf.learner, fold, econf.parser)
     print('learning ', econf.key, '...', file=sys.stderr)
     dpacks = subpacks.values()
     targets = [d.target for d in dpacks]

--- a/attelo/harness/report.py
+++ b/attelo/harness/report.py
@@ -20,7 +20,7 @@ import joblib
 
 from attelo.io import load_predictions
 from attelo.fold import (select_testing)
-from attelo.harness.util import (makedirs, md5sum_file)
+from attelo.harness.util import (makedirs, md5sum_dir, md5sum_file)
 from attelo.parser.intra import (IntraInterPair)
 from attelo.report import (EdgeReport,
                            CSpanReport,
@@ -450,7 +450,14 @@ def _mk_hashfile(hconf, dconf, test_data):
                 nice_path = fp.join(fold_basename, fp.basename(path))
             else:
                 nice_path = fp.basename(path)
-            print('\t'.join([nice_path, md5sum_file(path)]),
+            # get md5 sum of file or (NEW) dir
+            if fp.isfile(path):
+                path_hash = md5sum_file(path)
+            elif fp.isdir(path):
+                path_hash = md5sum_dir(path)
+            else:
+                raise ValueError("Unhashable stuff: {}".format(path))
+            print('\t'.join([nice_path, path_hash]),
                   file=stream)
 
 

--- a/attelo/harness/util.py
+++ b/attelo/harness/util.py
@@ -77,3 +77,19 @@ def md5sum_file(path, blocksize=65536):
             hasher.update(buf)
             buf = afile.read(blocksize)
     return hasher.hexdigest()
+
+
+def md5sum_dir(path, blocksize=65536):
+    """
+    Read a dir and return its md5 sum
+    """
+    hasher = hashlib.md5()
+    for dirpath, dirnames, filenames in os.walk(path):
+        for filename in filenames:
+            filepath = os.path.join(dirpath, filename)
+            with open(filepath, 'rb') as afile:
+                buf = afile.read(blocksize)
+                while len(buf) > 0:
+                    hasher.update(buf)
+                    buf = afile.read(blocksize)
+    return hasher.hexdigest()

--- a/attelo/io.py
+++ b/attelo/io.py
@@ -211,14 +211,24 @@ def _process_edu_links(edus, pairings):
 
 
 def load_multipack(edu_file, pairings_file, feature_file, vocab_file,
+                   corpus_reader=None,  # WIP
                    verbose=False):
-    """
-    Read EDUs and features for edu pairs.
+    """Read EDUs and features for edu pairs.
 
     Perform some basic sanity checks, raising
     :py:class:`IoException` if they should fail
 
-    :rtype: :py:class:`Multipack` or None
+    Parameters
+    ----------
+    ... TODO
+
+    corpus : WIP
+        TODO
+
+    Returns
+    -------
+    mpack: Multipack
+        Multipack (= dict) from grouping to DataPack.
     """
     vocab = load_vocab(vocab_file)
 
@@ -233,16 +243,30 @@ def load_multipack(edu_file, pairings_file, feature_file, vocab_file,
                                            n_features=len(vocab))
         # pylint: enable=unbalanced-tuple-unpacking
 
+    # WIP augment DataPack with the gold structure for each grouping
+    if corpus_reader is None:
+        ctargets = {}
+    else:
+        # FIXME should be [v] so that it is adapted to forests (lists)
+        # of structures, e.g. produced by for_intra()
+        ctargets = {k.doc: v for k, v in corpus_reader.slurp().items()}
+        # TODO modify educe.rst_dt.corpus.Reader.slurp_subcorpus() to
+        # convert fine-grained to coarse-grained relations by default,
+        # e.g. add kwarg coarse_rels=True, then find all current callers
+        # but this one and call slurp* with coarse_rels=False
+    # end WIP
+
     with Torpor("Build data packs", quiet=not verbose):
-        dpack = DataPack.load(edus, pairings, data, targets,
+        dpack = DataPack.load(edus, pairings, data, targets, ctargets,
                               labels, vocab)
 
-    return {k: dpack.selected(idxs) for
-            k, idxs in groupings(pairings).items()}
+    mpack = {grp_name: dpack.selected(idxs)
+             for grp_name, idxs in groupings(pairings).items()}
+    return mpack
 
 
 def load_vocab(filename):
-    "read feature vocabulary"
+    """Read feature vocabulary"""
     features = []
     with codecs.open(filename, 'r', 'utf-8') as stream:
         for line in stream:

--- a/attelo/io.py
+++ b/attelo/io.py
@@ -14,6 +14,8 @@ import traceback
 
 from sklearn.datasets import load_svmlight_file
 
+import educe  # WIP
+
 from .edu import (EDU, FAKE_ROOT_ID, FAKE_ROOT)
 from .table import (DataPack, DataPackException,
                     UNKNOWN, UNRELATED,
@@ -211,7 +213,7 @@ def _process_edu_links(edus, pairings):
 
 
 def load_multipack(edu_file, pairings_file, feature_file, vocab_file,
-                   corpus_reader=None,  # WIP
+                   corpus_path=None,  # WIP
                    verbose=False):
     """Read EDUs and features for edu pairs.
 
@@ -222,8 +224,10 @@ def load_multipack(edu_file, pairings_file, feature_file, vocab_file,
     ----------
     ... TODO
 
-    corpus : WIP
-        TODO
+    corpus_path : string
+        Path to the labelled corpus, to retrieve the original gold
+        structures ; at the moment, only works with the RST corpus to
+        access gold RST constituency trees.
 
     Returns
     -------
@@ -244,9 +248,10 @@ def load_multipack(edu_file, pairings_file, feature_file, vocab_file,
         # pylint: enable=unbalanced-tuple-unpacking
 
     # WIP augment DataPack with the gold structure for each grouping
-    if corpus_reader is None:
+    if corpus_path is None:
         ctargets = {}
     else:
+        corpus_reader = educe.rst_dt.corpus.Reader(corpus_path)
         # FIXME should be [v] so that it is adapted to forests (lists)
         # of structures, e.g. produced by for_intra()
         ctargets = {k.doc: v for k, v in corpus_reader.slurp().items()}

--- a/attelo/learning/local.py
+++ b/attelo/learning/local.py
@@ -106,7 +106,8 @@ class SklearnAttachClassifier(AttachClassifier, SklearnClassifier):
     def predict_score(self, dpack):
         if not self._fitted:
             raise ValueError('Fit not yet called')
-        elif self.can_predict_proba:
+
+        if self.can_predict_proba:
             attach_idx = list(self._learner.classes_).index(1)
             probs = self._learner.predict_proba(dpack.data)
             return probs[:, attach_idx]
@@ -145,10 +146,12 @@ class SklearnLabelClassifier(LabelClassifier, SklearnClassifier):
         return self
 
     def predict_score(self, dpack):
-        dpack, _ = for_labelling(dpack, dpack.target)
-        if self._labels is None:
-            raise ValueError('No labels associated with this classifier')
         if not self._fitted:
             raise ValueError('Fit not yet called')
+
+        if self._labels is None:
+            raise ValueError('No labels associated with this classifier')
+
+        dpack, _ = for_labelling(dpack, dpack.target)
         weights = self._learner.predict_proba(dpack.data)
         return relabel(self._labels, weights, dpack.labels)

--- a/attelo/learning/oracle.py
+++ b/attelo/learning/oracle.py
@@ -28,10 +28,10 @@ class AttachOracle(AttachClassifier):
         super(AttachOracle, self).__init__()
         self.can_predict_proba = True
 
-    def fit(self, dpacks, targets):
+    def fit(self, dpacks, targets, nonfixed_pairs=None):
         return self
 
-    def predict_score(self, dpack):
+    def predict_score(self, dpack, nonfixed_pairs=None):
         """Predict 1.0 for gold attachments, 0.0 otherwise.
 
         Notes
@@ -43,7 +43,20 @@ class AttachOracle(AttachClassifier):
         ----
         [ ] rename and refactor to predict_proba(self, dpacks)
         """
-        return np.where(dpack.target == 1, 1.0, 0.0)
+        if nonfixed_pairs is not None:
+            y_true = dpack.target[nonfixed_pairs]
+        else:
+            y_true = dpack.target
+
+        score_true = np.where(y_true == 1, 1.0, 0.0)
+
+        if nonfixed_pairs is not None:
+            res = np.copy(dpack.graph.attach)
+            res[nonfixed_pairs] = score_true
+        else:
+            res = score_true
+
+        return res
 
 
 class LabelOracle(LabelClassifier):
@@ -62,10 +75,10 @@ class LabelOracle(LabelClassifier):
         super(LabelOracle, self).__init__()
         self.can_predict_proba = True
 
-    def fit(self, dpacks, targets):
+    def fit(self, dpacks, targets, nonfixed_pairs=None):
         return self
 
-    def predict_score(self, dpack):
+    def predict_score(self, dpack, nonfixed_pairs=None):
         """Predict 1.0 for the gold label of edges.
 
         Non-gold edges are attributed "unknown" for their gold label.
@@ -87,9 +100,21 @@ class LabelOracle(LabelClassifier):
         weights = dok_matrix((len(dpack), len(dpack.labels)))
         lbl_unrelated = dpack.label_number(UNRELATED)
         lbl_unk = dpack.label_number(UNKNOWN)
-        for i, lbl in enumerate(dpack.target):
-            if lbl == lbl_unrelated:
-                weights[i, lbl_unk] = 1.0
-            else:
-                weights[i, lbl] = 1.0
+
+        if nonfixed_pairs is not None:
+            for i, lbl in enumerate(dpack.target):
+                if i in nonfixed_pairs:
+                    if lbl == lbl_unrelated:
+                        weights[i, lbl_unk] = 1.0
+                    else:
+                        weights[i, lbl] = 1.0
+                else:
+                    weights[i, :] = dpack.graph.label[i]
+        else:
+            for i, lbl in enumerate(dpack.target):
+                if lbl == lbl_unrelated:
+                    weights[i, lbl_unk] = 1.0
+                else:
+                    weights[i, lbl] = 1.0
+
         return weights.todense()

--- a/attelo/learning/util.py
+++ b/attelo/learning/util.py
@@ -8,11 +8,26 @@ from numpy import (zeros)
 
 
 def relabel(src_labels, src_weights, tgt_labels):
-    """
-    Rearrange the columns of a weight matrix to correspond to
+    """Rearrange the columns of a weight matrix to correspond to
     the new target label layout.
 
-    Target labels must be a superset of the source labels
+    Target labels must be a superset of the source labels.
+
+    Parameters
+    ----------
+    src_labels : iterable of int
+        List of source labels
+
+    src_weights : 2D matrix of float
+        Scores for each pairing and each possible label
+
+    tgt_labels : iterable of int
+        List of target labels
+
+    Returns
+    -------
+    tgt_weights : 2D matrix of float
+        Projection of src_weights with reordered columns
     """
     missing = [x for x in src_labels if x not in tgt_labels]
     if missing:

--- a/attelo/metrics/classification_structured.py
+++ b/attelo/metrics/classification_structured.py
@@ -1,0 +1,153 @@
+"""Classification metrics for structured outputs.
+
+"""
+
+from collections import Counter
+from itertools import chain, izip
+
+import numpy as np
+
+
+def _unique_labels(y):
+    """Set of unique labels in y"""
+    return set(y_ij[1] for y_ij in
+               chain.from_iterable(y_i for y_i in y))
+
+
+def unique_labels(*ys):
+    """Extract an ordered array of unique labels.
+
+    Parameters
+    ----------
+    elt_type: string
+        Type of each element, determines how to find the label
+
+    See also
+    --------
+    This is the structured version of
+    `sklearn.utils.multiclass.unique_labels`
+    """
+    ys_labels = set(chain.from_iterable(_unique_labels(y) for y in ys))
+    # TODO check the set of labels contains a unique (e.g. string) type
+    # of values
+    return np.array(sorted(ys_labels))
+
+
+def precision_recall_fscore_support(y_true, y_pred, labels=None,
+                                    average=None):
+    """Compute precision, recall, F-measure and support for each class.
+
+    The support is the number of occurrences of each class in
+    ``y_true``.
+
+    This is essentially a structured version of
+    sklearn.metrics.classification.precision_recall_fscore_support .
+
+    It should apply equally well to lists of constituency tree spans
+    and lists of dependency edges.
+
+    Parameters
+    ----------
+    y_true: list of iterable
+        Ground truth target structures, encoded in a sparse format (e.g.
+        list of edges or span descriptions).
+
+    y_pred: list of iterable
+        Estimated target structures, encoded in a sparse format (e.g. list
+        of edges or span descriptions).
+
+    labels: list, optional
+        The set of labels to include, and their order if ``average is
+        None``.
+
+    average: string, [None (default), 'binary', 'micro', 'macro']
+        If ``None``, the scores for each class are returned. Otherwise,
+        this determines the type of averaging performed on the data:
+
+        ``'binary'``:
+            Only report results for the positive class.
+            This is applicable only if targets are binary.
+        ``'micro'``:
+            Calculate metrics globally by counting the total true
+            positives, false negatives and false positives.
+        ``'macro'``:
+            Calculate metrics for each label, and find their unweighted
+            mean. This does not take label imbalance into account.
+
+    Returns
+    -------
+    precision: float (if average is not None) or array of float, shape=\
+        [n_unique_labels]
+
+    recall: float (if average is not None) or array of float, shape=\
+        [n_unique_labels]
+
+    fscore: float (if average is not None) or array of float, shape=\
+        [n_unique_labels]
+
+    support: int (if average is not None) or array of int, shape=\
+        [n_unique_labels]
+        The number of occurrences of each label in ``ctree_true``.
+    """
+    average_options = frozenset([None, 'micro', 'macro'])
+    if average not in average_options:
+        raise ValueError('average has to be one of' +
+                         str(average_options))
+    # TMP
+    if average == 'macro':
+        raise NotImplementedError('average currently has to be micro or None')
+    # end TMP
+
+    # gather an ordered list of unique labels from y_true and y_pred
+    present_labels = unique_labels(y_true, y_pred)
+
+    if labels is None:
+        labels = present_labels
+        # n_labels = None
+    else:
+        # EXPERIMENTAL
+        labels = [lbl for lbl in labels if lbl in present_labels]
+        # n_labels = len(labels)
+        # FIXME complete/fix this
+        # raise ValueError('Parameter `labels` is currently unsupported')
+        # end EXPERIMENTAL
+
+    # compute tp_sum, pred_sum, true_sum
+    # true positives for each tree
+    tp = [set(yi_true) & set(yi_pred)
+          for yi_true, yi_pred in izip(y_true, y_pred)]
+
+    # TODO find a nicer and faster design that resembles sklearn's, e.g.
+    # use np.bincount instead of collections.Counter
+    tp_sum = Counter(y_ij[1] for y_ij in chain.from_iterable(tp))
+    true_sum = Counter(y_ij[1] for y_ij in chain.from_iterable(y_true))
+    pred_sum = Counter(y_ij[1] for y_ij in chain.from_iterable(y_pred))
+    # transform to np arrays of floats
+    tp_sum = np.array([float(tp_sum[lbl]) for lbl in labels])
+    true_sum = np.array([float(true_sum[lbl]) for lbl in labels])
+    pred_sum = np.array([float(pred_sum[lbl]) for lbl in labels])
+
+    # TODO rewrite to compute by summing over scores broken down by label
+    if average == 'micro':
+        tp_sum = np.array([tp_sum.sum()])
+        true_sum = np.array([true_sum.sum()])
+        pred_sum = np.array([pred_sum.sum()])
+
+    # finally compute the desired statistics
+    # when the div denominator is 0, assign 0.0 (instead of np.inf)
+    precision = tp_sum / pred_sum
+    precision[pred_sum == 0] = 0.0
+
+    recall = tp_sum / true_sum
+    recall[true_sum == 0] = 0.0
+
+    f_score = 2 * (precision * recall) / (precision + recall)
+    f_score[precision + recall == 0] = 0.0
+
+    if average is not None:
+        precision = np.average(precision)
+        recall = np.average(recall)
+        f_score = np.average(f_score)
+        true_sum = np.average(true_sum)  # != sklearn: we keep the support
+
+    return precision, recall, f_score, true_sum

--- a/attelo/metrics/constituency.py
+++ b/attelo/metrics/constituency.py
@@ -10,224 +10,50 @@ evaluations, to avoid almost duplicates (as currently)
 
 from __future__ import print_function
 
-from collections import Counter
-import itertools
-from itertools import chain
-
 import numpy as np
 
+from .classification_structured import (precision_recall_fscore_support,
+                                        unique_labels)
 from .util import get_spans
 
 
-# util functions
-def _unique_span_length(y):
-    """Get the set of unique span length in y.
-
-    This assumes that elements of y are pairs of indices that describe
-    spans.
-    """
-    res = set(yi[1] - yi[0] for yi in chain.from_iterable(y))
-    return res
+# label extraction functions
+LBL_FNS = [
+    ('S', lambda span: span[0][1] - span[0][0]),  # scores by span length
+    ('S+N', lambda span: span[1]),
+    ('S+R', lambda span: span[2]),
+    ('S+N+R', lambda span: '{}-{}'.format(span[2], span[1])),
+]
 
 
-def _unique_lbl1(y):
-    """Get the set of unique labels in y.
-
-    This assumes that elements of y are tuples where the label is at
-    index 1.
-    """
-    res = set(yi[1] for yi in chain.from_iterable(y))
-    return res
-
-
-def _unique_lbl2(y):
-    """Get the set of unique labels in y.
-
-    This assumes that elements of y are tuples where the label is at
-    index 2.
-    """
-    res = set(yi[2] for yi in chain.from_iterable(y))
-    return res
-
-
-_FN_UNIQUE_LABELS = {
-    's': _unique_span_length,
-    's+n': _unique_lbl1,
-    's+r': _unique_lbl1,
-    's+n+r': _unique_lbl2,
-}
-
-
-def unique_labels(elt_type, *ys):
-    """Extract an ordered array of unique labels.
+def discourse_parseval_scores(ctree_true, ctree_pred, lbl_fn,
+                              labels=None, average=None):
+    """Compute discourse PARSEVAL scores for ctree_pred wrt ctree_true.
 
     Parameters
     ----------
-    elt_type: string
-        Type of each element, determines how to find the label
+    ctree_true : list of list of RSTTree or SimpleRstTree
 
-    See also
-    --------
-    `sklearn.utils.multiclass.unique_labels`
-    """
-    _unique_labels = _FN_UNIQUE_LABELS.get(elt_type, None)
-    if not _unique_labels:
-        raise ValueError('Unknown element type: ' + elt_type)
+    ctree_pred : list of list of RSTTree or SimpleRstTree
 
-    ys_labels = set(chain.from_iterable(_unique_labels(y) for y in ys))
-    # TODO check the set of labels contains a unique (e.g. string) type
-    # of values
-    return np.array(sorted(ys_labels))
-
-
-def precision_recall_fscore_support(y_true, y_pred, labels=None,
-                                    average=None,
-                                    elt_type='s'):
-    """Compute precision, recall, F-measure and support for each class.
-
-    The support is the number of occurrences of each class in
-    ``y_true``.
-
-    Parameters
-    ----------
-    y_true: list of iterable
-        Ground truth target trees, encoded in a sparse format (e.g. list
-        of edges or constituent descriptions).
-
-    y_pred: list of iterable
-        Estimated targets as returned by a classifier with
-        tree-structured outputs. Each tree is encoded in a sparse format
-        (e.g. list of either constituents or edges).
-
-    labels: list, optional
-        The set of labels to include, and their order if ``average is
-        None``.
-
-    average: string, [None (default), 'binary', 'micro', 'macro']
-        If ``None``, the scores for each class are returned. Otherwise,
-        this determines the type of averaging performed on the data:
-
-        ``'binary'``:
-            Only report results for the positive class.
-            This is applicable only if targets are binary.
-        ``'micro'``:
-            Calculate metrics globally by counting the total true
-            positives, false negatives and false positives.
-        ``'macro'``:
-            Calculate metrics for each label, and find their unweighted
-            mean. This does not take label imbalance into account.
-
-    elt_type: string, ['s' (default), 's+n', 's+r', 's+n+r']
-        Type of each element of each yi of each y
+    labels : list of string, optional
+        Corresponds to sklearn's target_names IMO
 
     Returns
     -------
-    precision: float (if average is not None) or array of float, shape=\
+    precision : float (if average is not None) or array of float, shape =\
+        [n_unique_labels]
+        Weighted average of the precision of each class.
+
+    recall : float (if average is not None) or array of float, shape =\
         [n_unique_labels]
 
-    recall: float (if average is not None) or array of float, shape=\
+    fbeta_score : float (if average is not None) or array of float, shape =\
         [n_unique_labels]
 
-    fscore: float (if average is not None) or array of float, shape=\
-        [n_unique_labels]
-
-    support: int (if average is not None) or array of int, shape=\
+    support : int (if average is not None) or array of int, shape =\
         [n_unique_labels]
         The number of occurrences of each label in ``ctree_true``.
-    """
-    average_options = frozenset([None, 'micro', 'macro'])
-    if average not in average_options:
-        raise ValueError('average has to be one of' +
-                         str(average_options))
-    # TEMPORARY
-    if average not in set(['micro', None]):
-        raise NotImplementedError('average currently has to be micro or None')
-
-    # gather an ordered list of unique labels from y_true and y_pred
-    present_labels = unique_labels(elt_type, y_true, y_pred)
-
-    if labels is None:
-        labels = present_labels
-        n_labels = None
-    else:
-        # EXPERIMENTAL
-        labels = [lbl for lbl in labels if lbl in present_labels]
-        n_labels = len(labels)
-        # FIXME complete/fix this
-        # raise ValueError('Parameter `labels` is currently unsupported')
-        # end EXPERIMENTAL
-
-    # compute tp_sum, pred_sum, true_sum
-    # true positives for each tree
-    tp = [set(yi_true) & set(yi_pred)
-          for yi_true, yi_pred in itertools.izip(y_true, y_pred)]
-
-    # TODO refactor to share code with _FN_UNIQUE_LABELS
-    if elt_type == 's':
-        _lbl_fn = lambda yi: yi[1] - yi[0]
-    elif elt_type == 's+n':
-        _lbl_fn = lambda yi: yi[1]
-    elif elt_type == 's+r':
-        _lbl_fn = lambda yi: yi[1]
-    elif elt_type == 's+n+r':
-        _lbl_fn = lambda yi: yi[2]
-    else:
-        raise ValueError('elt_type {} not supported'.format(elt_type))
-
-    # TODO find a nicer and faster design that resembles sklearn's, e.g.
-    # use np.bincount
-    #
-    # collect using Counter
-    tp_sum = Counter(_lbl_fn(yi) for yi in chain.from_iterable(tp))
-    true_sum = Counter(_lbl_fn(yi) for yi in chain.from_iterable(y_true))
-    pred_sum = Counter(_lbl_fn(yi) for yi in chain.from_iterable(y_pred))
-    # transform to np arrays of floats
-    tp_sum = np.array([float(tp_sum[lbl]) for lbl in labels])
-    true_sum = np.array([float(true_sum[lbl]) for lbl in labels])
-    pred_sum = np.array([float(pred_sum[lbl]) for lbl in labels])
-
-    # TODO rewrite to compute by summing over scores broken down by label
-    if average == 'micro':
-        tp_sum = np.array([tp_sum.sum()])
-        true_sum = np.array([true_sum.sum()])
-        pred_sum = np.array([pred_sum.sum()])
-        if False:  # extra checks  # false when labels is not None
-            ctrl_tp_sum = sum(len(tp_i) for tp_i in tp)
-            assert ctrl_tp_sum == tp_sum
-            ctrl_true_sum = sum(len(yi_true) for yi_true in y_true)
-            assert ctrl_true_sum == true_sum
-            ctrl_pred_sum = sum(len(yi_pred) for yi_pred in y_pred)
-            assert ctrl_pred_sum == pred_sum
-
-    # finally compute the desired statistics
-    # when the div denominator is 0, assign 0.0 (instead of np.inf)
-    precision = tp_sum / pred_sum
-    precision[pred_sum == 0] = 0.0
-
-    recall = tp_sum / true_sum
-    recall[true_sum == 0] = 0.0
-
-    f_score = 2 * (precision * recall) / (precision + recall)
-    f_score[precision + recall == 0] = 0.0
-
-    return precision, recall, f_score, true_sum
-
-
-def compute_parseval_scores(ctree_true, ctree_pred, average=None,
-                            exclude_rel_span=False):
-    """Compute (and display) PARSEVAL scores for ctree_pred wrt ctree_true.
-
-    Parameters
-    ----------
-    ctree_true: dict(string, SimpleRstTree)
-
-    ctree_pred: dict(string, SimpleRstTree)
-
-    average: TODO complete using the above function
-
-    Returns
-    -------
-    FIXME return scores
 
     References
     ----------
@@ -235,92 +61,146 @@ def compute_parseval_scores(ctree_true, ctree_pred, average=None,
            parsing and summarization." MIT press.
 
     """
-    labels = None  # FIXME check this is the right default value
-    # coarse labels except for span
-    # FIXME pass as parameters or move elsewhere ; this might be too
-    # RST-dependent
-    clabels_wo_span = [
-        'attribution',
-        'background',
-        'cause',
-        'comparison',
-        'condition',
-        'contrast',
-        'elaboration',
-        'enablement',
-        'evaluation',
-        'explanation',
-        'joint',
-        'manner-means',
-        'same-unit',
-        'summary',
-        'temporal',
-        'textual',
-        'topic-change',
-        'topic-comment',
-    ]
 
-    # extract the minimally relevant description of each constituent
-    snr_true = [get_spans(ct_true) for ct_true in ctree_true]
-    snr_pred = [get_spans(ct_pred) for ct_pred in ctree_pred]
+    # extract descriptions of spans from the true and pred trees
+    spans_true = [get_spans(ct_true) for ct_true in ctree_true]
+    spans_pred = [get_spans(ct_pred) for ct_pred in ctree_pred]
+    # use lbl_fn to define labels
+    spans_true = [[(span[0], lbl_fn(span)) for span in spans]
+                  for spans in spans_true]
+    spans_pred = [[(span[0], lbl_fn(span)) for span in spans]
+                  for spans in spans_pred]
 
-    # we need 4 different metrics: S, S+N, S+R, S+N+R
-    # spans
-    s_true = [[c[0] for c in cs] for cs in snr_true]
-    s_pred = [[c[0] for c in cs] for cs in snr_pred]
-    # spans + nuclearity
-    sn_true = [[(c[0], c[1]) for c in cs] for cs in snr_true]
-    sn_pred = [[(c[0], c[1]) for c in cs] for cs in snr_pred]
-    # spans + relation
-    sr_true = [[(c[0], c[2]) for c in cs] for cs in snr_true]
-    sr_pred = [[(c[0], c[2]) for c in cs] for cs in snr_pred]
-    # spans + nuclearity + relation
-    # already computed, see above
+    p, r, f, s = precision_recall_fscore_support(spans_true, spans_pred,
+                                                 labels=labels,
+                                                 average=average)
+    return p, r, f, s
 
-    # display
-    # TODO don't do this here + automate/loop
-    # calculate metrics globally
-    target_names = unique_labels('s', s_true, s_pred)
-    precision, recall, f_score, support = precision_recall_fscore_support(
-        s_true, s_pred, labels=labels, average=average, elt_type='s')
-    print('\tP\tR\tF\tsupport')
-    print('============================================')
-    print('S')
-    print('\n'.join('{}\t{:.4f}\t{:.4f}\t{:.4f}\t{:.0f}'.format(l, p, r, f, s)
-                    for l, p, r, f, s in itertools.izip(
-                            target_names,
-                            precision, recall, f_score, support)))
-    print('--------------------------------------------')
-    target_names = unique_labels('s+n', sn_true, sn_pred)
-    precision, recall, f_score, support = precision_recall_fscore_support(
-        sn_true, sn_pred, labels=labels, average=average, elt_type='s+n')
-    print('S+N')
-    print('\n'.join('{}\t{:.4f}\t{:.4f}\t{:.4f}\t{:.0f}'.format(l, p, r, f, s)
-                    for l, p, r, f, s in itertools.izip(
-                            target_names,
-                            precision, recall, f_score, support)))
-    print('--------------------------------------------')
-    target_names = unique_labels('s+r', sr_true, sr_pred)
-    if exclude_rel_span:
-        labels = clabels_wo_span
-        target_names = [lbl for lbl in target_names if lbl != 'span']
-    precision, recall, f_score, support = precision_recall_fscore_support(
-        sr_true, sr_pred, labels=labels, average=average, elt_type='s+r')
-    print('S+R')
-    print('\n'.join('{}\t{:.4f}\t{:.4f}\t{:.4f}\t{:.0f}'.format(l, p, r, f, s)
-                    for l, p, r, f, s in itertools.izip(
-                            target_names,
-                            precision, recall, f_score, support)))
-    print('--------------------------------------------')
-    target_names = unique_labels('s+n+r', snr_true, snr_pred)
-    if exclude_rel_span:
-        labels = clabels_wo_span
-        target_names = [lbl for lbl in target_names if lbl != 'span']
-    precision, recall, f_score, support = precision_recall_fscore_support(
-        snr_true, snr_pred, labels=labels, average=average, elt_type='s+n+r')
-    print('S+N+R')
-    print('\n'.join('{}\t{:.4f}\t{:.4f}\t{:.4f}\t{:.0f}'.format(l, p, r, f, s)
-                    for l, p, r, f, s in itertools.izip(
-                            target_names,
-                            precision, recall, f_score, support)))
-    print('--------------------------------------------')
+
+def parseval_report(ctree_true, ctree_pred, labels=None, lbl_fn=None,
+                    average=None, digits=2):
+    """Build a text report showing the PARSEVAL discourse metrics.
+
+    FIXME model after sklearn.metrics.classification.classification_report
+
+    Parameters
+    ----------
+    ctree_true : list of RSTTree or SimpleRstTree
+        Ground truth (correct) target structures.
+
+    ctree_pred : list of RSTTree or SimpleRstTree
+        Estimated target structures as predicted by a parser.
+
+    labels : list of string, optional
+        Relation labels to include in the evaluation.
+        FIXME Corresponds more to target_names in sklearn IMHO.
+
+    lbl_fn : function from tuple((int, int), string, string) to string
+        Label extraction function
+
+    digits : int
+        Number of digits for formatting output floating point values.
+
+    Returns
+    -------
+    report : string
+        Text summary of the precision, recall, F1 score, support for each
+        class (or micro-averaged over all classes).
+
+    References
+    ----------
+    .. [1] `Daniel Marcu (2000). "The theory and practice of discourse
+           parsing and summarization." MIT press.
+
+    """
+
+    if labels is None:
+        labels = unique_labels(ctree_true, ctree_pred)
+
+    last_line_heading = 'avg / total'
+
+    width = max(len(lbl) for lbl in labels)
+    width = max(width, len(last_line_heading), digits)
+
+    headers = ["precision", "recall", "f1-score", "support"]
+    fmt = '%% %ds' % width  # first col: class name
+    fmt += '  '
+    fmt += ' '.join(['% 9s' for _ in headers])
+    fmt += '\n'
+
+    headers = [""] + headers
+    report = fmt % tuple(headers)
+    report += '\n'
+
+    # call with average=None to compute per-class scores, then
+    # compute average here and print it
+    p, r, f1, s = discourse_parseval_scores(ctree_true, ctree_pred,
+                                            labels=labels,
+                                            lbl_fn=lbl_fn,
+                                            average=None)
+    # one line per label
+    for i, label in enumerate(labels):
+        values = [label]
+        for v in (p[i], r[i], f1[i]):
+            values += ["{0:0.{1}f}".format(v, digits)]
+        values += ["{0}".format(s[i])]
+        if average is None:  # print per-class scores for average=None only
+            report += fmt % tuple(values)
+
+    # print only if per-class scores
+    if average is None:
+        report += '\n'
+
+    # compute averages for the bottom line
+    values = [last_line_heading]
+    for v in (np.average(p, weights=s),
+              np.average(r, weights=s),
+              np.average(f1, weights=s)):
+        values += ["{0:0.{1}f}".format(v, digits)]
+    values += ['{0}'.format(np.sum(s))]
+    report += fmt % tuple(values)
+
+    return report
+
+
+def parseval_reports(ctree_true, ctree_pred, labels=None, average=None,
+                     digits=2):
+    """Build a text report showing the PARSEVAL discourse metrics.
+
+    FIXME model after sklearn.metrics.classification.classification_report
+
+    Parameters
+    ----------
+    ctree_true : list of RSTTree or SimpleRstTree
+        Ground truth (correct) target structures.
+
+    ctree_pred : list of RSTTree or SimpleRstTree
+        Estimated target structures as predicted by a parser.
+
+    labels : list of string, optional
+        Relation labels to include in the evaluation.
+        FIXME Corresponds more to target_names in sklearn IMHO.
+
+    digits : int
+        Number of digits for formatting output floating point values.
+
+    Returns
+    -------
+    report : string
+        Text summary of the precision, recall, F1 score, support for each
+        class (or micro-averaged over all classes).
+
+    References
+    ----------
+    .. [1] `Daniel Marcu (2000). "The theory and practice of discourse
+           parsing and summarization." MIT press.
+
+    """
+    # extract one report per type of metric
+    reports = [(metric_type, parseval_report(ctree_true, ctree_pred,
+                                             labels=labels,
+                                             lbl_fn=lbl_fn,
+                                             average=average,
+                                             digits=digits))
+               for metric_type, lbl_fn in LBL_FNS]
+    return reports

--- a/attelo/metrics/constituency.py
+++ b/attelo/metrics/constituency.py
@@ -16,6 +16,8 @@ from itertools import chain
 
 import numpy as np
 
+from .util import get_spans
+
 
 # util functions
 def _unique_span_length(y):
@@ -258,41 +260,20 @@ def compute_parseval_scores(ctree_true, ctree_pred, average=None,
         'topic-comment',
     ]
 
-    # collect all constituents, i.e. all treenodes except for the root
-    # node (as is done in Marcu's 2000 book and Joty's eval script)
-    tns_true = [[subtree.label()  # was: educe.internalutil.treenode(subtree)
-                 for root_child in ct_true
-                 for subtree in root_child.subtrees()]
-                for ct_true in ctree_true]
     # extract the minimally relevant description of each constituent
-    snr_true = [[(tn.edu_span, tn.nuclearity, tn.rel)
-                 for tn in tns]
-                for tns in tns_true]
-    # same for pred
-    tns_pred = [[subtree.label()  # was: educe.internalutil.treenode(subtree)
-                 for root_child in ct_pred
-                 for subtree in root_child.subtrees()]
-                for ct_pred in ctree_pred]
-    snr_pred = [[(tn.edu_span, tn.nuclearity, tn.rel)
-                 for tn in tns]
-                for tns in tns_pred]
+    snr_true = [get_spans(ct_true) for ct_true in ctree_true]
+    snr_pred = [get_spans(ct_pred) for ct_pred in ctree_pred]
 
     # we need 4 different metrics: S, S+N, S+R, S+N+R
     # spans
-    s_true = [[c[0] for c in cs]
-              for cs in snr_true]
-    s_pred = [[c[0] for c in cs]
-              for cs in snr_pred]
+    s_true = [[c[0] for c in cs] for cs in snr_true]
+    s_pred = [[c[0] for c in cs] for cs in snr_pred]
     # spans + nuclearity
-    sn_true = [[(c[0], c[1]) for c in cs]
-               for cs in snr_true]
-    sn_pred = [[(c[0], c[1]) for c in cs]
-               for cs in snr_pred]
+    sn_true = [[(c[0], c[1]) for c in cs] for cs in snr_true]
+    sn_pred = [[(c[0], c[1]) for c in cs] for cs in snr_pred]
     # spans + relation
-    sr_true = [[(c[0], c[2]) for c in cs]
-               for cs in snr_true]
-    sr_pred = [[(c[0], c[2]) for c in cs]
-               for cs in snr_pred]
+    sr_true = [[(c[0], c[2]) for c in cs] for cs in snr_true]
+    sr_pred = [[(c[0], c[2]) for c in cs] for cs in snr_pred]
     # spans + nuclearity + relation
     # already computed, see above
 
@@ -324,7 +305,7 @@ def compute_parseval_scores(ctree_true, ctree_pred, average=None,
         labels = clabels_wo_span
         target_names = [lbl for lbl in target_names if lbl != 'span']
     precision, recall, f_score, support = precision_recall_fscore_support(
-    sr_true, sr_pred, labels=labels, average=average, elt_type='s+r')
+        sr_true, sr_pred, labels=labels, average=average, elt_type='s+r')
     print('S+R')
     print('\n'.join('{}\t{:.4f}\t{:.4f}\t{:.4f}\t{:.0f}'.format(l, p, r, f, s)
                     for l, p, r, f, s in itertools.izip(

--- a/attelo/metrics/tree.py
+++ b/attelo/metrics/tree.py
@@ -36,7 +36,7 @@ def tree_loss(ref_tree, pred_tree):
     it does not differentiate between incorrectly attached edges and
     correctly attached but incorrectly labelled edges.
     """
-    return 1.0 - (len(set(pred_tree) & set(ref_tree))/ float(len(ref_tree)))
+    return 1.0 - (len(set(pred_tree) & set(ref_tree)) / float(len(ref_tree)))
 
 
 def labelled_tree_loss(ref_tree, pred_tree):
@@ -70,7 +70,7 @@ def labelled_tree_loss(ref_tree, pred_tree):
     """
     edges_ref = {tgt: (src, lbl) for src, tgt, lbl in ref_tree}
     edges_pred = {tgt: (src, lbl) for src, tgt, lbl in pred_tree}
-    
+
     score = 0.0
     for tgt in sorted(set(edges_ref) & set(edges_pred)):
         head_ref, lbl_ref = edges_ref[tgt]

--- a/attelo/metrics/util.py
+++ b/attelo/metrics/util.py
@@ -1,0 +1,178 @@
+"""
+Temporary place for utilities related to classification metrics.
+
+This currently contains code to rebuild constituency trees from
+dependency trees in attelo parlance and enumerate constituency tree
+spans for evaluation.
+
+Another motivation of this module is to contain and confine educe
+imports.
+"""
+
+from __future__ import print_function
+
+from collections import defaultdict
+import itertools
+
+from educe.annotation import Span as EduceSpan
+from educe.rst_dt.annotation import (EDU as EduceEDU,
+                                     RSTTree,
+                                     SimpleRSTTree)
+from educe.rst_dt.dep2con import (deptree_to_simple_rst_tree,
+                                  DummyNuclearityClassifier,
+                                  InsideOutAttachmentRanker)
+from educe.rst_dt.deptree import (RstDepTree,
+                                  RstDtException)
+
+from attelo.table import UNKNOWN
+
+
+def get_oracle_ctrees(dep_edges, att_edus,
+                      nuc_strategy="unamb_else_most_frequent",
+                      rank_strategy="closest-intra-rl-inter-rl",
+                      prioritize_same_unit=True):
+    """Build oracle constituency trees from a dependency tree.
+
+    Parameters
+    ----------
+    dep_edges : dict(string, [(string, string, string)])
+        Edges for each document, indexed by doc name
+        Cf. type of return value from
+        irit-rst-dt/ctree.py:load_attelo_output_file()
+
+    att_edus : cf return type of attelo.io.load_edus
+        EDUs as they are known to attelo
+
+    Returns
+    -------
+    ctrees: list of RstTree
+        There can be several e.g. for leaky sentences.
+    """
+    # rebuild educe EDUs from their attelo description
+    # and group them by doc_name
+    educe_edus = defaultdict(list)
+    edu2sent_idx = defaultdict(dict)
+    gid2num = dict()
+    for att_edu in att_edus:
+        # doc name
+        doc_name = att_edu.grouping
+        # EDU info
+        # skip ROOT (automatically added by RstDepTree.__init__)
+        if att_edu.id == 'ROOT':
+            continue
+        edu_num = int(att_edu.id.rsplit('_', 1)[1])
+        edu_span = EduceSpan(att_edu.start, att_edu.end)
+        edu_text = att_edu.text
+        educe_edus[doc_name].append(EduceEDU(edu_num, edu_span, edu_text))
+        # map global id of EDU to num of EDU inside doc
+        gid2num[att_edu.id] = edu_num
+        # map EDU to sentence
+        sent_idx = int(att_edu.subgrouping.split('_sent')[1])
+        edu2sent_idx[doc_name][edu_num] = sent_idx
+    # check that our info covers only one document
+    assert len(educe_edus) == 1
+    # then restrict to this document
+    doc_name = educe_edus.keys()[0]
+    educe_edus = educe_edus[doc_name]
+    edu2sent_idx = edu2sent_idx[doc_name]
+    # sort EDUs by num
+    educe_edus = list(sorted(educe_edus, key=lambda e: e.num))
+    # rebuild educe-style edu2sent ; prepend 0 for the fake root
+    edu2sent = [0] + [edu2sent_idx[e.num] for e in educe_edus]
+    # classifiers for nuclearity and ranking
+    # FIXME declare, fit and predict upstream...
+    # nuclearity
+    nuc_classifier = DummyNuclearityClassifier(strategy=nuc_strategy)
+    nuc_classifier.fit([], [])  # empty X and y for dummy fit
+    # ranking classifier
+    rank_classifier = InsideOutAttachmentRanker(
+        strategy=rank_strategy,
+        prioritize_same_unit=prioritize_same_unit)
+
+    # rebuild RstDepTrees
+    dtree = RstDepTree(educe_edus)
+    for src_id, tgt_id, lbl in dep_edges:
+        if src_id == 'ROOT':
+            if lbl == 'ROOT' or lbl == UNKNOWN:
+                dtree.set_root(gid2num[tgt_id])
+            else:
+                raise ValueError('Weird root label: {}'.format(lbl))
+        else:
+            dtree.add_dependency(gid2num[src_id], gid2num[tgt_id], lbl)
+    # add nuclearity: heuristic baseline
+    dtree.nucs = nuc_classifier.predict([dtree])[0]
+    # add rank: some strategies require a mapping from EDU to sentence
+    # EXPERIMENTAL attach array of sentence index for each EDU in tree
+    dtree.sent_idx = edu2sent
+    # end EXPERIMENTAL
+    dtree.ranks = rank_classifier.predict([dtree])[0]
+    # end NEW
+
+    # create pred ctree
+    try:
+        bin_srtrees = deptree_to_simple_rst_tree(dtree, allow_forest=True)
+        if False:  # EXPERIMENTAL
+            # currently False to run on output that already has
+            # labels embedding nuclearity
+            bin_srtrees = [SimpleRSTTree.incorporate_nuclearity_into_label(
+                bin_srtree) for bin_srtree in bin_srtrees]
+        bin_rtrees = [SimpleRSTTree.to_binary_rst_tree(bin_srtree)
+                      for bin_srtree in bin_srtrees]
+    except RstDtException as rst_e:
+        print(rst_e)
+        if False:
+            print('\n'.join('{}: {}'.format(edu.text_span(), edu)
+                            for edu in educe_edus[doc_name]))
+        raise
+    ctrees = bin_rtrees
+
+    return ctrees
+
+
+def get_spans(ctree):
+    """Get the spans of a constituency tree, except for the root node.
+
+    This corresponds to the spans used in the PARSEVAL metric modified
+    for discourse, as described in (Marcu 2000) and implemented in
+    Joty's evaluation scripts.
+
+    Each span is descried by a triplet (edu_span, nuclearity, relation).
+    """
+    tnodes = [subtree.label()  # was: educe.internalutil.treenode(subtree)
+              for root_child in ctree if isinstance(root_child, RSTTree)
+              for subtree in root_child.subtrees()]
+    spans = [(tn.edu_span, tn.nuclearity, tn.rel)
+             for tn in tnodes]
+    return spans
+
+
+def oracle_ctree_spans(dep_edges, att_edus):
+    """Get the spans of the oracle ctree for a given dtree.
+
+    Parameters
+    ----------
+    att_edus : cf return type of attelo.io.load_edus
+        EDUs as they are known to attelo
+
+    dep_edges : dict(string, [(string, string, string)])
+        Edges for each document, indexed by doc name
+        Cf. type of return value from
+        irit-rst-dt/ctree.py:load_attelo_output_file()
+
+    att_edus: list of attelo EDUs
+        List of attelo EDUs
+
+    dtree: RstDepTree
+        Dtree for which we want the spans of the oracle ctree.
+
+    Returns
+    -------
+    spans: list of ((int, int), string, string)
+        List of spans, described as (edu_span, nuclearity, relation)
+    """
+    # a single dependency tree with several real roots corresponds
+    # to a forest of constituency trees
+    oracle_ctrees = get_oracle_ctrees(dep_edges, att_edus)
+    oracle_spans = list(itertools.chain.from_iterable(
+        [get_spans(oracle_ctree) for oracle_ctree in oracle_ctrees]))
+    return oracle_spans

--- a/attelo/parser/attach.py
+++ b/attelo/parser/attach.py
@@ -36,11 +36,11 @@ class AttachClassifierWrapper(Parser):
         """
         Parameters
         ----------
-        attach_learner: AttachClassifier
+        attach_learner : AttachClassifier
         """
         self._learner_attach = learner_attach
 
-    def fit(self, dpacks, targets, cache=None):
+    def fit(self, dpacks, targets, nonfixed_pairs=None, cache=None):
         """
         Extract whatever models or other information from the multipack
         that is necessary to make the parser operational
@@ -58,16 +58,18 @@ class AttachClassifierWrapper(Parser):
             return self
 
         dpacks, targets = self.dzip(for_attachment, dpacks, targets)
-        self._learner_attach.fit(dpacks, targets)
+        self._learner_attach.fit(dpacks, targets,
+                                 nonfixed_pairs=nonfixed_pairs)
         # save classifier, if necessary
         if cache_file is not None:
             # print('\tsave {}'.format(cache_file))
             joblib.dump(self._learner_attach, cache_file)
         return self
 
-    def transform(self, dpack):
+    def transform(self, dpack, nonfixed_pairs=None):
         attach_pack, _ = for_attachment(dpack, dpack.target)
-        weights_a = self._learner_attach.predict_score(attach_pack)
+        weights_a = self._learner_attach.predict_score(
+            attach_pack, nonfixed_pairs=nonfixed_pairs)
         dpack = self.multiply(dpack, attach=weights_a)
         return dpack
 

--- a/attelo/parser/full.py
+++ b/attelo/parser/full.py
@@ -23,10 +23,10 @@ class AttachTimesBestLabel(Parser):
     and something downstream to make predictions (otherwise
     it's UNKNOWN everywhere)
     """
-    def fit(self, dpacks, targets, cache=None):
+    def fit(self, dpacks, targets, nonfixed_pairs=None, cache=None):
         return
 
-    def transform(self, dpack):
+    def transform(self, dpack, nonfixed_pairs=None):
         dpack = self.multiply(dpack)
         weights_a = dpack.graph.attach
         weights_l = dpack.graph.label

--- a/attelo/parser/intra.py
+++ b/attelo/parser/intra.py
@@ -81,10 +81,17 @@ def for_intra(dpack, target):
     new_target = np.copy(dpack.target)
     new_target[all_heads] = dpack.label_number('ROOT')
     new_target[inter_links] = unrelated  # NEW
+    # WIP ctarget
+    new_ctarget = {grp_name: ctgt
+                   for grp_name, ctgt in dpack.ctarget.items()}
+    # FIXME replace each ctgt with the list of intra-sentential
+    # RST (sub)trees
+    # end WIP ctarget
     dpack = DataPack(edus=dpack.edus,
                      pairings=dpack.pairings,
                      data=dpack.data,
                      target=new_target,
+                     ctarget=new_ctarget,
                      labels=dpack.labels,
                      vocab=dpack.vocab,
                      graph=dpack.graph)

--- a/attelo/parser/intra.py
+++ b/attelo/parser/intra.py
@@ -258,7 +258,7 @@ class IntraInterParser(with_metaclass(ABCMeta, Parser)):
             # find all EDUs that have intra incoming edges in gold (to rule
             # out)
             unrelated = dpack.label_number(UNRELATED)
-            pairs_true = np.where(target != unrelated)
+            pairs_true = np.where(target != unrelated)[0]
             pairs_intra = idxes_intra(dpack, include_fake_root=False)
             pairs_intra_true = np.intersect1d(pairs_true, pairs_intra)
             intra_tgts = set(dpack.pairings[i][1].id
@@ -359,7 +359,10 @@ class IntraInterParser(with_metaclass(ABCMeta, Parser)):
         else:
             dpacks_inter, targets_inter = dpacks, targets
 
+        inter_indices = [idxes_inter(dpack_inter, include_fake_root=True)
+                         for dpack_inter in dpacks_inter]
         self._parsers.inter.fit(dpacks_inter, targets_inter,
+                                nonfixed_pairs=inter_indices,
                                 cache=caches.inter)
         return self
 
@@ -834,7 +837,8 @@ class FrontierToHeadParser(IntraInterParser):
             # so we can instruct the inter parser to keep its nose
             # out of intra stuff
             inter_indices = idxes_inter(dpack_inter, include_fake_root=True)
-            dpack_inter = self._parsers.inter.transform(dpack_inter)
+            dpack_inter = self._parsers.inter.transform(
+                dpack_inter, nonfixed_pairs=inter_indices)
 
         doc_lbl = self._mk_get_lbl(dpack, [dpack_inter])
 

--- a/attelo/parser/pipeline.py
+++ b/attelo/parser/pipeline.py
@@ -21,11 +21,12 @@ class Pipeline(Parser):
     def __init__(self, steps):
         self._parsers = [p for _, p in steps]
 
-    def fit(self, dpacks, targets, cache=None):
+    def fit(self, dpacks, targets, nonfixed_pairs=None, cache=None):
         for parser in self._parsers:
-            parser.fit(dpacks, targets, cache=cache)
+            parser.fit(dpacks, targets, nonfixed_pairs=nonfixed_pairs,
+                       cache=cache)
 
-    def transform(self, dpack):
+    def transform(self, dpack, nonfixed_pairs=None):
         for parser in self._parsers:
-            dpack = parser.transform(dpack)
+            dpack = parser.transform(dpack, nonfixed_pairs=nonfixed_pairs)
         return dpack

--- a/attelo/parser/tests.py
+++ b/attelo/parser/tests.py
@@ -51,23 +51,20 @@ DEFAULT_ASTAR_ARGS = AstarArgs(heuristics=Heuristic.average,
 # select a decoder and a learner team
 MST_DECODER = MstDecoder(root_strategy=MstRootStrategy.fake_root)
 ASTAR_DECODER = AstarDecoder(DEFAULT_ASTAR_ARGS)
-DECODERS =\
-    [
-        LastBaseline(),
-        LocalBaseline(0.5, use_prob=False),
-        MST_DECODER,
-        ASTAR_DECODER,
-        LocallyGreedy(),
-        Pipeline(steps=[('window pruner', WindowPruner(2)),
-                        ('decoder', ASTAR_DECODER)]),
-    ]
+DECODERS = [
+    LastBaseline(),
+    LocalBaseline(0.5, use_prob=False),
+    MST_DECODER,
+    ASTAR_DECODER,
+    LocallyGreedy(),
+    Pipeline(steps=[('window pruner', WindowPruner(2)),
+                    ('decoder', ASTAR_DECODER)]),
+]
 
-LEARNERS =\
-    [
-        Team(attach=SklearnAttachClassifier(LogisticRegression()),
-             label=SklearnLabelClassifier(LogisticRegression())),
-
-    ]
+LEARNERS = [
+    Team(attach=SklearnAttachClassifier(LogisticRegression()),
+         label=SklearnLabelClassifier(LogisticRegression())),
+]
 
 
 class ParserTest(DecoderTest):
@@ -154,9 +151,10 @@ class IntraTest(unittest.TestCase):
                                                             [1], [1], [1],
                                                             [1], [1], [1],
                                                             [1]]),
-                              target=np.array([2, 1, 1, 3, 1, 3, 1, 3, 1,
+                              target=np.array([2, 1, 1, 3, 1, 3, 1, 1, 1,
                                                1, 1, 2, 3, 1, 3, 1, 1, 1,
                                                3]),
+                              ctarget=dict(),  # WIP
                               labels=orig_classes,
                               vocab=None)
         return dpack
@@ -205,14 +203,18 @@ class IntraTest(unittest.TestCase):
 
     def test_intra_parsers(self):
         'test all intra/inter parsers on a dpack'
-        learner = Team(attach=SklearnAttachClassifier(LogisticRegression()),
-                       label=SklearnLabelClassifier(LogisticRegression()))
+        learner_intra = Team(
+            attach=SklearnAttachClassifier(LogisticRegression()),
+            label=SklearnLabelClassifier(LogisticRegression()))
+        learner_inter = Team(
+            attach=SklearnAttachClassifier(LogisticRegression()),
+            label=SklearnLabelClassifier(LogisticRegression()))
         # note: these are chosen a bit randomly
-        p_intra = JointPipeline(learner_attach=learner.attach,
-                                learner_label=learner.label,
+        p_intra = JointPipeline(learner_attach=learner_intra.attach,
+                                learner_label=learner_intra.label,
                                 decoder=MST_DECODER)
-        p_inter = PostlabelPipeline(learner_attach=learner.attach,
-                                    learner_label=learner.label,
+        p_inter = PostlabelPipeline(learner_attach=learner_inter.attach,
+                                    learner_label=learner_inter.label,
                                     decoder=MST_DECODER)
         parsers = [mk_p(IntraInterPair(intra=p_intra,
                                        inter=p_inter))

--- a/attelo/table.py
+++ b/attelo/table.py
@@ -419,6 +419,31 @@ def groupings(pairings):
     return res
 
 
+def idxes_attached(dpack, target):
+    """Indices of attached pairings from dpack, according to target.
+
+    Parameters
+    ----------
+    dpack : DataPack
+        Datapack
+    target : list of integers
+        Label for each pairings of dpack
+
+    Returns
+    -------
+    indices : array of integers
+        Indices of attached pairings.
+
+    TODO
+    ----
+    Try and apply widely, especially for parser.intra ;
+    search for e.g. "target != unrelated" and "target[i] != unrelated".
+    """
+    unrelated = dpack.label_number(UNRELATED)
+    indices = np.where(target != unrelated)[0]
+    return indices
+
+
 def attached_only(dpack, target):
     """
     Return only the instances which are labelled as


### PR DESCRIPTION
This PR adds a handful of new features:
* possible integration of {c,d}tree loss functions in training of structured learners,
* better constituency tree eval,
* new intra/inter parser: FrontierToHead,
* fixed intra/inter oracles
* `nonfixed_pairs` param enables to explicitly list candidate edges for which a prediction is expected.

It also brings along several fixes for existing parsers and decoders, especially Eisner.