### PR TITLE
FIX score.build_confusion_matrix re-align y_gold, y_pred

### DIFF
--- a/attelo/score.py
+++ b/attelo/score.py
@@ -332,13 +332,20 @@ def score_edges_by_label(dpack, predictions):
 def build_confusion_matrix(dpack, predictions):
     """return a confusion matrix show predictions vs desired labels
     """
-    pred_target = [dpack.label_number(label) for _, _, label in predictions]
+    # first, we need to align target_true and target_pred
+    # FIXME avoid this costly operation: make sure that dpack.pairings
+    # and dpack.target keep the same ordering as in the .pairings file ;
+    # we need to find where this ordering is lost
+    tgt_dict_true = {(src.id, tgt.id): lbl for (src, tgt), lbl
+                     in zip(dpack.pairings, dpack.target)}
+    target_true = [tgt_dict_true[(src, tgt)] for src, tgt, _ in predictions]
+    target_pred = [dpack.label_number(label) for _, _, label in predictions]
     # we want the confusion matrices to have the same shape regardless
     # of what labels happen to be used in the particular fold
     # pylint: disable=no-member
     labels = np.arange(0, len(dpack.labels))
     # pylint: enable=no-member
-    return confusion_matrix(dpack.target, pred_target, labels)
+    return confusion_matrix(target_true, target_pred, labels)
 
 
 def empty_confusion_matrix(dpack):

--- a/attelo/score.py
+++ b/attelo/score.py
@@ -336,9 +336,9 @@ def build_confusion_matrix(dpack, predictions):
     # FIXME avoid this costly operation: make sure that dpack.pairings
     # and dpack.target keep the same ordering as in the .pairings file ;
     # we need to find where this ordering is lost
-    tgt_dict_true = {(src.id, tgt.id): lbl for (src, tgt), lbl
+    lbl_dict_true = {(src.id, tgt.id): lbl for (src, tgt), lbl
                      in zip(dpack.pairings, dpack.target)}
-    target_true = [tgt_dict_true[(src, tgt)] for src, tgt, _ in predictions]
+    target_true = [lbl_dict_true[(src, tgt)] for src, tgt, _ in predictions]
     target_pred = [dpack.label_number(label) for _, _, label in predictions]
     # we want the confusion matrices to have the same shape regardless
     # of what labels happen to be used in the particular fold


### PR DESCRIPTION
This PR contains a small fix for a long-standing bug affecting confusion matrices.

The pairings in a dpack often end up being in a different order than the original pairings listed in the `.pairings` file, whereas the predictions seem to follow the original order.

I hope future releases will prevent this from happening or make re-alignment less costly, but this PR fixes the issue locally: `y_gold` and `y_pred` are re-aligned so `confusion_matrix` gets truly comparable arguments.