### PR TITLE
FIX discriminating features

### DIFF
--- a/attelo/learning/local.py
+++ b/attelo/learning/local.py
@@ -33,7 +33,7 @@ class SklearnClassifier(object):
         best: [(int, float)]
             index within the input weight array, and score
         """
-        best_idxes = np.argsort(np.absolute(weights))[-top_n:][::-1]
+        best_idxes = np.argsort(weights)[-top_n:][::-1]
         best_weights = np.take(weights, best_idxes)
         return zip(best_idxes, best_weights)
 

--- a/attelo/report.py
+++ b/attelo/report.py
@@ -714,6 +714,8 @@ def show_discriminating_features(listing):
         List of (label, features) pairs; the features are themselves a
         list of (feature, weight) pairs.
     """
-    rows = [[label] + concat_l(feats) for
-            label, feats in listing]
-    return tabulate(_condense_table(_sort_table(rows)))
+    rows = []
+    for label, feats in listing:
+        rows.append([label] + list(feats[0]))
+        rows.extend([''] + list(x) for x in feats[1:])
+    return tabulate(rows)


### PR DESCRIPTION
This PR fixes the computation and display of the most discriminating features of a classifier.

The most discriminating features are now the ones with the highest (relative) weight, whereas we used to take their absolute value (on my initiative, IIRC).
The corresponding table display now has one line per feature, has a fixed order for classes and does not try to condense consecutive lines that share a prefix. The aim is to enable line-by-line comparison of most discriminating features between models.