### PR TITLE
ENH customize reports: number of digits for floats

### DIFF
--- a/attelo/cmd/report.py
+++ b/attelo/cmd/report.py
@@ -42,6 +42,10 @@ def config_argparser(psr):
                      help="only report on this fold")
     psr.add_argument("--output", metavar="DIR",
                      help="save report to this file")
+    # 2017-02-22 number of digits (precision) for floats in report
+    psr.add_argument("--digits", metavar="DIGITS",
+                     default=3,
+                     help="number of digits to display floats in report")
     psr.set_defaults(func=main)
 
 
@@ -106,5 +110,5 @@ def main(args):
                        edge_by_rel=rel_report,
                        confusion=cmatrix,
                        confusion_labels=dpack.labels)
-    rpack.dump(output_dir)
+    rpack.dump(output_dir, digits=args.digits)
     announce_output_dir(output_dir)

--- a/attelo/harness/interface.py
+++ b/attelo/harness/interface.py
@@ -11,23 +11,23 @@ from .config import RuntimeConfig
 
 
 class HarnessException(Exception):
-    """Things that go wrong in the test harness itself
+    """Things that go wrong in the test harness itself.
     """
     pass
 
 
 class Harness(with_metaclass(ABCMeta, object)):
-    """Test harness configuration
+    """Test harness configuration.
 
     Among other things, this is about defining conventions for
-    filepaths
+    filepaths.
 
     Notes
     -----
     You should have a method that calls `load`.
-    It should be invoked once before running the harness
+    It should be invoked once before running the harness.
     A natural idiom may be to implement a single `run` function
-    that does this
+    that does this.
     """
 
     # pylint: disable=too-many-arguments
@@ -37,12 +37,12 @@ class Harness(with_metaclass(ABCMeta, object)):
         """
         Parameters
         ----------
-        dataset: string
+        dataset : string
             Basename for training data files
 
-        testset: string or None
+        testset : string or None
             Basename for test data files.
-            None if there is no test set set
+            None if there is no test set set.
 
         """
         self.dataset = dataset
@@ -146,6 +146,18 @@ class Harness(with_metaclass(ABCMeta, object)):
         Set of evaluations for which we would like detailed reporting
         """
         return []
+
+    @property
+    def metrics(self):
+        """Selection of metrics to compute in reports."""
+        # default metrics: ['edges', 'edges_by_label', 'edus']
+        return ['edges', 'edges_by_label', 'edus']
+
+    @property
+    def report_digits(self):
+        """Number of digits to display floats in reports."""
+        # default value: 3
+        return 3
 
     @property
     def graph_docs(self):
@@ -276,17 +288,20 @@ class Harness(with_metaclass(ABCMeta, object)):
     def report_dir_path(self, test_data,
                         fold=None,
                         is_tmp=True):
-        """
-        Path to a directory containing reports.
+        """Path to a directory containing reports.
 
         Parameters
         ----------
-        test_data: bool
+        test_data : bool
+            If True, the report is about the test set, otherwise the
+            (usually, training) dataset.
 
-        fold: int
+        fold : int, optional
+            Number of the fold under scrutiny ; if None, all folds.
 
-        is_tmp: bool
-            Only return the path to a provisional report in progress
+        is_tmp : bool, defaults to True
+            If True, only return the path to a provisional report in
+            progress.
         """
         if not is_tmp:
             parent_dir = self.eval_dir

--- a/attelo/harness/report.py
+++ b/attelo/harness/report.py
@@ -106,9 +106,19 @@ class ReportPack(namedtuple('ReportPack',
                 filenames[fkey] = fp.join(confusion_dir, '-'.join(key))
         return filenames
 
-    def dump(self, output_dir, header=None):
-        """
-        Save reports to an output directory
+    def dump(self, output_dir, header=None, digits=3):
+        """Save reports to an output directory.
+
+        Parameters
+        ----------
+        output_dir : str
+            Output folder.
+
+        header : str, optional
+            Additional header text to display.
+
+        digits : int, defaults to 3
+            Number of digits for formatting output floating point values.
         """
         makedirs(output_dir)
         fnames = self._filenames(output_dir).values()
@@ -116,19 +126,21 @@ class ReportPack(namedtuple('ReportPack',
         for fname in fnames:
             with open(fname, 'w'):
                 pass
-        self.append(output_dir, header=header)
+        self.append(output_dir, header, digits=digits)
 
-    def append(self, output_dir, header):
-        """
-        Append reports to a pre-existing output directory
+    def append(self, output_dir, header, digits=3):
+        """Append reports to a pre-existing output directory.
 
         Parameters
         ----------
-        header: string or None
-            name for the tables
+        output_dir : str
+            Output folder.
 
-        hint: string or None
-            additional header text to display
+        header : str
+            Additional header text to display.
+
+        digits : int, defaults to 3
+            Number of digits for formatting output floating point values.
         """
         longheader = header + ' ({} edges)'.format(self.num_edges)
         fnames = self._filenames(output_dir)
@@ -139,7 +151,7 @@ class ReportPack(namedtuple('ReportPack',
                     longheader,
                     '=' * len(longheader),
                     '',
-                    self.edge.table(),
+                    self.edge.table(digits=digits),
                     ''
                 ]
                 print('\n'.join(block), file=ostream)
@@ -151,7 +163,7 @@ class ReportPack(namedtuple('ReportPack',
                     longheader,
                     '=' * len(longheader),
                     '',
-                    self.cspan.table(),
+                    self.cspan.table(digits=digits),
                     '',
                 ]
                 print('\n'.join(block), file=ostream)
@@ -160,7 +172,8 @@ class ReportPack(namedtuple('ReportPack',
         if self.edu is not None:
             # edu scores
             with open(fnames['edu'], 'a') as ostream:
-                print(self.edu.table(main_header=header), file=ostream)
+                print(self.edu.table(main_header=header, digits=digits),
+                      file=ostream)
                 print(file=ostream)
 
         if self.edge_by_label is not None:
@@ -168,7 +181,7 @@ class ReportPack(namedtuple('ReportPack',
                 fkey = ('label', key)
                 with open(fnames[fkey], 'a') as ostream:
                     print(report.table(sortkey=lambda (_, v): 0 - v.count,
-                                       main_header=header),
+                                       main_header=header, digits=digits),
                           file=ostream)
                     print(file=ostream)
 
@@ -223,27 +236,31 @@ def full_report(mpack, fold_dict, slices, metrics,
 
     Parameters
     ----------
-    mpack: TODO
+    mpack : TODO
         TODO
-    fold_dict: TODO
+
+    fold_dict : TODO
         TODO
-    slices: iterable of Slice
+
+    slices : iterable of Slice
         Predictions for each configuration, for each fold.
         Folds should be contiguous for maximum efficiency.
         It may be worthwhile to generate this lazily.
-    metrics: iterable of {'edges', 'edges_by_label', 'edus', 'cspans'}
+
+    metrics : iterable of {'edges', 'edges_by_label', 'edus', 'cspans'}
         Set of selected metrics.
         For the RST corpus, 'cspans' should not be selected for evaluation
         on the intra, inter and root subsets until I find out how to restrict
         RSTTrees along DataPack.selected().
-    adjust_pack: function from DataPack to DataPack, optional
+
+    adjust_pack : function from DataPack to DataPack, optional
         Function that modifies a DataPack, for example by picking out a
         subset of the pairings.
 
 
     Returns
     -------
-    rpack: ReportPack
+    rpack : ReportPack
         Group of reports on a set of folds and configurations.
 
     TODO
@@ -498,9 +515,27 @@ def _copy_version_files(hconf, test_data):
 
 
 def _mk_report(hconf, dconf, slices, fold, test_data=False):
-    """helper for report generation
+    """Helper for report generation.
 
-    :type fold: int or None
+    Parameters
+    ----------
+    hconf : attelo.harness.interface.Harness
+        Harness configuration.
+
+    dconf : TODO
+        TODO
+
+    slices : TODO
+        TODO
+
+    fold : int or None
+        Number of the fold to report.
+
+    test_data : boolean, defaults to False
+        If True, report on the test data.
+
+    digits : int, defaults to 3
+        Number of digits for formatting output floating point values.
     """
     # we could just use slices = list(slices) here but we have a
     # bit of awkward lazy IO where it says 'scoring fold N...'
@@ -510,7 +545,7 @@ def _mk_report(hconf, dconf, slices, fold, test_data=False):
     slices_ = itr.tee(slices, 4)
     rpack = full_report(dconf.pack, dconf.folds, slices_[0], hconf.metrics)
     rdir = hconf.report_dir_path(test_data, fold)
-    rpack.dump(rdir, header='whole')
+    rpack.dump(rdir, header='whole', digits=hconf.report_digits)
 
     # TMP exclude cspan eval for subsets of edges
     subeval_metrics = [x for x in hconf.metrics if x != 'cspans']
@@ -523,7 +558,7 @@ def _mk_report(hconf, dconf, slices, fold, test_data=False):
         rpack = full_report(dconf.pack, dconf.folds, slices_[i],
                             subeval_metrics,
                             adjust_pack=adjust_pack)
-        rpack.append(rdir, header=header)
+        rpack.append(rdir, header, digits=hconf.report_digits)
     # FIXME what we really want is the set of (learner, data_selection)
     # with data_selection: all pairings for global parsers ; all intra
     # pairings + one of several possible subsets of the inter pairings
@@ -534,13 +569,13 @@ def _mk_report(hconf, dconf, slices, fold, test_data=False):
 
 
 def mk_fold_report(hconf, dconf, fold):
-    "Generate reports for the given fold"
+    """Generate reports for the given fold"""
     slices = _fold_report_slices(hconf, fold)
     _mk_report(hconf, dconf, slices, fold)
 
 
 def mk_global_report(hconf, dconf):
-    "Generate reports for all folds"
+    """Generate reports for all folds"""
     slices = itr.chain.from_iterable(_fold_report_slices(hconf, f)
                                      for f in frozenset(dconf.folds.values()))
     _mk_report(hconf, dconf, slices, None)
@@ -560,7 +595,7 @@ def mk_global_report(hconf, dconf):
 
 
 def mk_test_report(hconf, dconf):
-    "Generate reports for test data"
+    """Generate reports for test data"""
     econf = hconf.test_evaluation
     if econf is None:
         return
@@ -570,8 +605,7 @@ def mk_test_report(hconf, dconf):
                     configuration=_report_key(econf),
                     predictions=load_predictions(p_path),
                     enable_details=True)]
-    _mk_report(hconf, dconf, slices, None,
-               test_data=True)
+    _mk_report(hconf, dconf, slices, None, test_data=True)
     _copy_version_files(hconf, True)
 
     report_dir = hconf.report_dir_path(True, fold=None)

--- a/attelo/report.py
+++ b/attelo/report.py
@@ -262,8 +262,14 @@ class Multiscore(object):
             scores["confidence_interval"] = mean - int0
         return scores
 
-    def summary(self):
-        "One line summary string"
+    def summary(self, digits=3):
+        """One line summary string.
+
+        Parameters
+        ----------
+        digits : int, defaults to 3
+            Number of digits for formatting floating point values.
+        """
 
         if self._check_can_compute_confidence():
             mean, (int0, _) = self.confidence_interval(lambda x: x.f1)
@@ -271,19 +277,23 @@ class Multiscore(object):
             mean, int0 = (0, 0)
 
         output = []
-        output.append("Prec=%1.3f, Recall=%1.3f," %
-                      (self.score.precision,
-                       self.score.recall))
-        output.append("F1=%1.3f +/- %1.3f (%1.3f +- %1.3f)" %
-                      (self.score.f1,
-                       self.standard_error(lambda x: x.f1),
-                       mean,
-                       mean - int0))
+        output.append("Prec={:1.{digits}f}, Recall={:1.{digits}f},".format(
+            self.score.precision,
+            self.score.recall,
+            digits=digits))
+        output.append("F1={:1.{digits}f} +/- {:1.{digits}f} "
+                      "({:1.{digits}f} +- {:1.{digits}f})".format(
+                          self.score.f1,
+                          self.standard_error(lambda x: x.f1),
+                          mean,
+                          mean - int0,
+                          digits=digits))
         if self.score.f1_corr is not None:
             output.append("\t with recall correction estimate, "
-                          "R=%1.3f, F1=%1.3f" %
-                          (self.score.recall_corr,
-                           self.score.f1_corr))
+                          "R={:1.{digits}f}, F1={:1.{digits}f}".format(
+                              self.score.recall_corr,
+                              self.score.f1_corr,
+                              digits=digits))
         return " ".join(output)
 
     def table_row(self):
@@ -351,13 +361,13 @@ class EdgeReport(object):
                   "rfc={rfc}")
         return pieces.format(**self.params.__dict__)
 
-    def summary(self):
-        "One line summary string"
+    def summary(self, digits=3):
+        """One line summary string"""
 
         output = [self._params_to_filename(),
-                  "\tATT", self.attach_dir.summary(),
-                  "\t+DIR", self.attach_undir.summary(),
-                  "\t+LAB", self.label.summary()]
+                  "\tATT", self.attach_dir.summary(digits=digits),
+                  "\t+DIR", self.attach_undir.summary(digits=digits),
+                  "\t+LAB", self.label.summary(digits=digits)]
         return " ".join(output)
 
     def table_row(self):
@@ -442,15 +452,15 @@ class CSpanReport(object):
                   "rfc={rfc}")
         return pieces.format(**self.params.__dict__)
 
-    def summary(self):
+    def summary(self, digits=3):
         "One line summary string"
 
         output = [
             self._params_to_filename(),
-            "\tS", self.score_s.summary(),
-            "\tS+N", self.score_sn.summary(),
-            "\tS+R", self.score_sr.summary(),
-            "\tS+N+R", self.score_snr.summary(),
+            "\tS", self.score_s.summary(digits=digits),
+            "\tS+N", self.score_sn.summary(digits=digits),
+            "\tS+R", self.score_sr.summary(digits=digits),
+            "\tS+N+R", self.score_snr.summary(digits=digits),
         ]
         return " ".join(output)
 
@@ -565,7 +575,7 @@ class CombinedReport(object):
         "dictionary from config name (string) to Report"
     # pylint: enable=pointless-string-statement
 
-    def table(self, main_header=None, sortkey=None):
+    def table(self, main_header=None, sortkey=None, digits=3):
         """
         2D tabular output
 
@@ -589,7 +599,7 @@ class CombinedReport(object):
                 for k in keys]
         return tabulate(rows,
                         headers=headers,
-                        floatfmt=".3f")
+                        floatfmt=".{digits}f".format(digits=digits))
 
     def for_json(self):
         """

--- a/attelo/tests.py
+++ b/attelo/tests.py
@@ -90,6 +90,7 @@ class DataPackTest(unittest.TestCase):
                           triv.pairings,
                           triv.data,
                           [1, 1],
+                          dict(),  # ctarget, DIRTY
                           ['__UNK__', 'UNRELATED', 'foo'],
                           None)
 

--- a/attelo/tests.py
+++ b/attelo/tests.py
@@ -50,6 +50,7 @@ class DataPackTest(unittest.TestCase):
                             data=scipy.sparse.csr_matrix([[6, 8],
                                                           [7, 0]]),
                             target=numpy.array([1, 0]),
+                            ctarget=dict(),  # DIRTY
                             labels=['__UNK__', 'x', 'UNRELATED'],
                             graph=None,
                             vocab=None)

--- a/attelo/tests.py
+++ b/attelo/tests.py
@@ -41,6 +41,7 @@ class DataPackTest(unittest.TestCase):
                        pairings=[(edus[0], edus[1])],
                        data=scipy.sparse.csr_matrix([[6, 8]]),
                        target=numpy.array([1]),
+                       ctarget=dict(),  # DIRTY
                        labels=['__UNK__', 'x', 'UNRELATED'],
                        graph=None,
                        vocab=None)
@@ -106,12 +107,14 @@ class DataPackTest(unittest.TestCase):
                                       [(self.edus[0], FAKE_ROOT)],
                                       triv.data,
                                       triv.target,
+                                      dict(),  # ctarget: DIRTY
                                       triv.labels,
                                       None))
         dpack2 = DataPack.load(triv.edus,
                                triv.pairings,
                                triv.data,
                                triv.target,
+                               dict(),  # ctarget: DIRTY
                                triv.labels,
                                None)
         self.assertEqualishDatapack(triv, dpack2)
@@ -125,6 +128,7 @@ class DataPackTest(unittest.TestCase):
                                   (self.edus[2], self.edus[0])],
                         data=scipy.sparse.csr_matrix([[6], [7], [1], [5]]),
                         target=numpy.array([2, 1, 1, 3]),
+                        ctarget=dict(),  # DIRTY
                         labels=['__UNK__', 'x', 'y', 'UNRELATED'],
                         graph=None,
                         vocab=None)
@@ -151,6 +155,7 @@ class DataPackTest(unittest.TestCase):
                                                            [7, 0],
                                                            [3, 9]]),
                              target=numpy.array([3, 4, 2]),
+                             ctarget=dict(),  # DIRTY
                              labels=orig_classes,
                              vocab=None)
 
@@ -183,6 +188,7 @@ class DataPackTest(unittest.TestCase):
                                     pairings=[(a1, a2)],
                                     data=scipy.sparse.csr_matrix([[6, 8]]),
                                     target=numpy.array([1]),
+                                    ctarget=dict(),  # DIRTY
                                     labels=labels,
                                     vocab=None),
                  'b': DataPack.load(edus=[b1, b2],
@@ -191,18 +197,21 @@ class DataPackTest(unittest.TestCase):
                                     data=scipy.sparse.csr_matrix([[7, 0],
                                                                   [3, 9]]),
                                     target=numpy.array([0, 1]),
+                                    ctarget=dict(),  # DIRTY
                                     labels=labels,
                                     vocab=None),
                  'c': DataPack.load(edus=[c1, c2],
                                     pairings=[(c1, c2)],
                                     data=scipy.sparse.csr_matrix([[1, 1]]),
                                     target=numpy.array([1]),
+                                    ctarget=dict(),  # DIRTY
                                     labels=labels,
                                     vocab=None),
                  'd': DataPack.load(edus=[d1, d2],
                                     pairings=[(d1, d2)],
                                     data=scipy.sparse.csr_matrix([[0, 4]]),
                                     target=numpy.array([0]),
+                                    ctarget=dict(),  # DIRTY
                                     labels=labels,
                                     vocab=None)}
         fold_dict = {'a': 0,


### PR DESCRIPTION
This PR enables harnesses to customize the precision (number of digits) of floats in reports.

It also fixes a few docstrings and calls in related code, and sets a default list of evaluation metrics for harnesses.