### PR TITLE
ENH mpack paths dict

### DIFF
--- a/attelo/harness/evaluate.py
+++ b/attelo/harness/evaluate.py
@@ -207,8 +207,7 @@ def do_global_decode(hconf, dconf):
 
 
 def _load_harness_multipack(hconf, test_data=False):
-    """
-    Load the multipack for our current configuration.
+    """Load the multipack for our current configuration.
 
     Load the stripped features file if we don't actually need to
     use the features (this would only make sense on the cluster
@@ -217,24 +216,25 @@ def _load_harness_multipack(hconf, test_data=False):
 
     Parameters
     ----------
-    test_data: bool
+    test_data : bool, defaults to False
+        If True, it's test data we wanted.
 
     Returns
     -------
-    mpack: Multipack
+    mpack : Multipack
+        Multipack loaded from the harness' configuration.
     """
     stripped_paths = hconf.mpack_paths(test_data, stripped=True)
     if (hconf.runcfg.stage in [ClusterStage.end, ClusterStage.start] and
-        fp.exists(stripped_paths[2])):
+        fp.exists(stripped_paths['features'])):
         paths = stripped_paths
     else:
         paths = hconf.mpack_paths(test_data, stripped=False)
-    mpack = load_multipack(paths[0],
-                           paths[1],
-                           paths[2],
-                           paths[3],
-                           corpus_path=(paths[4] if len(paths) == 5
-                                        else None),  # WIP
+    mpack = load_multipack(paths['edu_input'],
+                           paths['pairings'],
+                           paths['features'],
+                           paths['vocab'],
+                           corpus_path=paths.get('corpus', None),  # WIP
                            verbose=True)
     return mpack
 

--- a/attelo/harness/example.py
+++ b/attelo/harness/example.py
@@ -84,11 +84,18 @@ class TinyHarness(Harness):
         return attelo.fold.make_n_fold(mpack, 2, None)
 
     def mpack_paths(self, _, stripped=False):
+        """Return a dict of paths needed to read a datapack.
+
+        The 2nd argument denoted by '_' is test_data, which is unused in
+        this example.
+        """
         core_path = fp.join(self._datadir, 'tiny')
-        return (core_path + '.edus',
-                core_path + '.pairings',
-                core_path + '.features.sparse',
-                core_path + '.features.sparse.vocab')
+        return {
+            'edu_input': core_path + '.edus',
+            'pairings': core_path + '.pairings',
+            'features': core_path + '.features.sparse',
+            'vocab': core_path + '.features.sparse.vocab'
+        }
 
     def _model_basename(self, rconf, mtype, ext):
         "Basic filename for a model"

--- a/attelo/harness/interface.py
+++ b/attelo/harness/interface.py
@@ -196,22 +196,27 @@ class Harness(with_metaclass(ABCMeta, object)):
 
     @abstractmethod
     def mpack_paths(self, test_data, stripped=False):
-        """
-        Return a tuple of paths needed to read a datapack
+        """Return a dict of paths needed to read a datapack.
 
-        * features
-        * edu input
+        Usual keys are:
+        * edu_input
         * pairings
-        * vocabulary
+        * features
+        * vocab
 
         Parameters
         ----------
-        test_data: bool
-            if it's test data we wanted
+        test_data : bool
+            If True, it's test data we wanted.
 
-        stripped: bool
-            return path for a "stripped" version of the data
-            (faster loading, but only useful for scoring)
+        stripped : bool, defaults to False
+            If True, return path for a "stripped" version of the data
+            (faster loading, but only useful for scoring).
+
+        Returns
+        -------
+        res : dict
+            Paths to files that enable to read a datapack.
         """
         return NotImplementedError
 

--- a/attelo/harness/report.py
+++ b/attelo/harness/report.py
@@ -462,9 +462,10 @@ def _mk_model_summary(hconf, dconf, rconf, test_data, fold, parser):
 def _mk_hashfile(hconf, dconf, test_data):
     "Hash the features and models files for long term archiving"
     # data files
-    hash_me = list(hconf.mpack_paths(False))
+    hash_me = [v for k, v in sorted(hconf.mpack_paths(False).items())]
     if hconf.test_evaluation is not None:
-        hash_me.extend(hconf.mpack_paths(True))
+        hash_me.extend(
+            [v for k, v in sorted(hconf.mpack_paths(True).items())])
 
     # model files
     model_files = []

--- a/attelo/score.py
+++ b/attelo/score.py
@@ -156,7 +156,7 @@ def score_edges(dpack, predictions):
 
 
 def score_cspans(dpacks, dpredictions, coarse_rels=True, binary_trees=True,
-                 oracle_ctree_gold=False):
+                 oracle_ctree_gold=False, verbose=1):
     """Count correctly predicted spans.
 
     Parameters
@@ -175,7 +175,12 @@ def score_cspans(dpacks, dpredictions, coarse_rels=True, binary_trees=True,
 
     oracle_ctree_gold : boolean, optional
         If True, use oracle gold constituency trees, rebuilt from the
-        gold dependency tree. This should emulate the evaluation in (Li 2014).
+        gold dependency tree. This should emulate the evaluation in
+        (Li 2014).
+
+    verbose : int, defaults to 1
+        Verbosity level ; currently set to 1 because it's still
+        considered WIP.
 
     Returns
     -------
@@ -239,12 +244,17 @@ def score_cspans(dpacks, dpredictions, coarse_rels=True, binary_trees=True,
         y_pred = [[(span[0], lbl_fn(span)) for span in ctree_spans]
                   for ctree_spans in ctree_spans_preds]
         # WIP
-        print('{}\t'.format(metric_type) +
-              '\t'.join(str(x) for x in
-                        precision_recall_fscore_support(y_true, y_pred,
-                                                        labels=None,
-                                                        average='micro')))
+        if verbose:
+            digits = 4
+            values = [metric_type]
+            p, r, f1, s = precision_recall_fscore_support(
+                y_true, y_pred, labels=None, average='micro')
+            for v in (p, r, f1):
+                values += ["{0:0.{1}f}".format(v, digits)]
+            values += ["{0}".format(s)]
+            print('\t'.join(values))
         # end WIP
+
         # FIXME replace with calls to attelo.metrics.classification_structured.
         # precision_recall_fscore_support(y_true, y_pred, labels=None,
         # average='micro')


### PR DESCRIPTION
This PR changes the type of the return value of mpack_paths, from a tuple to a dict.
A named tuple could have been a viable alternative but a dict provides greater flexibility, enabling harnesses to specify their own set of keys.